### PR TITLE
fix: resolve LID JIDs to phone-number JIDs before storing messages

### DIFF
--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -95,14 +95,37 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 	return name
 }
 
+// ResolveLIDToPhone converts a LID JID to a phone-number-based JID using the local store.
+// If the JID is not a LID or the mapping is not found, returns the original JID unchanged.
+func (c *Client) ResolveLIDToPhone(jid types.JID) types.JID {
+	if jid.Server != types.HiddenUserServer {
+		return jid
+	}
+
+	if c.Store.LIDs == nil {
+		c.logger.Warnf("LID store not available, cannot resolve %s", jid.String())
+		return jid
+	}
+
+	phoneJID, err := c.Store.LIDs.GetPNForLID(context.Background(), jid)
+	if err != nil || phoneJID.IsEmpty() {
+		c.logger.Warnf("Could not resolve LID %s to phone number: %v", jid.String(), err)
+		return jid
+	}
+
+	c.logger.Infof("Resolved LID %s -> %s", jid.String(), phoneJID.String())
+	return phoneJID
+}
+
 // HandleMessage processes regular incoming messages with media support and webhook processing
 func (c *Client) HandleMessage(messageStore *database.MessageStore, webhookManager interface{}, msg *events.Message) {
-	// Save message to database
-	chatJID := msg.Info.Chat.String()
+	// Resolve LID JIDs to phone-number JIDs so messages are stored under the correct chat
+	resolvedChat := c.ResolveLIDToPhone(msg.Info.Chat)
+	chatJID := resolvedChat.String()
 	sender := msg.Info.Sender.User
 
 	// Get appropriate chat name (pass nil for conversation since we don't have one for regular messages)
-	name := c.GetChatName(messageStore, msg.Info.Chat, chatJID, nil, sender)
+	name := c.GetChatName(messageStore, resolvedChat, chatJID, nil, sender)
 
 	// Update chat in database with the message timestamp (keeps last message time updated)
 	err := messageStore.StoreChat(chatJID, name, msg.Info.Timestamp)
@@ -173,14 +196,18 @@ func (c *Client) HandleHistorySync(messageStore *database.MessageStore, historyS
 			continue
 		}
 
-		chatJID := *conversation.ID
+		rawJID := *conversation.ID
 
 		// Try to parse the JID
-		jid, err := types.ParseJID(chatJID)
+		jid, err := types.ParseJID(rawJID)
 		if err != nil {
-			c.logger.Warnf("Failed to parse JID %s: %v", chatJID, err)
+			c.logger.Warnf("Failed to parse JID %s: %v", rawJID, err)
 			continue
 		}
+
+		// Resolve LID JIDs to phone-number JIDs
+		jid = c.ResolveLIDToPhone(jid)
+		chatJID := jid.String()
 
 		// Get appropriate chat name by passing the history sync conversation directly
 		name := c.GetChatName(messageStore, jid, chatJID, conversation, "")


### PR DESCRIPTION
## Summary

WhatsApp has been migrating from phone-number-based JIDs (`56984245696@s.whatsapp.net`) to **LID (Linked Identity Device)** JIDs (`64471787692117@lid`). This causes messages to be stored under the wrong chat, effectively splitting conversations in the database.

**What happens today:**
1. You send a message to a contact from your phone
2. The bridge receives the echo-back event, but `msg.Info.Chat` now contains a LID JID (e.g. `64471787692117@lid`) instead of the phone-number JID (`56984245696@s.whatsapp.net`)
3. The message gets stored under a ghost chat with the LID JID
4. Querying messages by the contact's phone-number JID returns an incomplete conversation — the sent message is missing

**The fix:**
- Adds `ResolveLIDToPhone()` which checks if a chat JID uses the `@lid` server and converts it to the corresponding phone-number JID using whatsmeow's built-in `Store.LIDs.GetPNForLID()` (queries the `whatsmeow_lid_map` table that whatsmeow populates during contact sync)
- If no mapping is found, falls back gracefully to the original LID JID
- Applied to both `HandleMessage` (real-time messages) and `HandleHistorySync` (initial history download)

## How I found this

Docker logs showed this when sending a message:
```
Getting name for contact: 64471787692117@lid
Using contact name: 21268896202986
```

Instead of the expected:
```
Using existing chat name for 56984245696@s.whatsapp.net: Francisco Monge
```

The `whatsmeow_lid_map` table in the whatsmeow store already had the correct mapping (`64471787692117 → 56984245696`), it just wasn't being used.

## Test plan

- [ ] Send a message from phone to a contact, verify docker logs show `Resolved LID ... -> ...@s.whatsapp.net`
- [ ] Verify the message appears under the phone-number chat JID in the messages DB
- [ ] Receive a message from a contact, verify it still stores correctly
- [ ] Verify group messages (`@g.us`) are unaffected (they bypass LID resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)