### PR TITLE
feat: store WhatsApp call events as messages

### DIFF
--- a/whatsapp-bridge/internal/whatsapp/client.go
+++ b/whatsapp-bridge/internal/whatsapp/client.go
@@ -147,10 +147,6 @@ func (c *Client) Connect() error {
 			if evt.Event == "code" {
 				fmt.Println("\nScan this QR code with your WhatsApp app:")
 				qrterminal.GenerateHalfBlock(evt.Code, qrterminal.L, os.Stdout)
-				// Write QR code string and HTML to /tmp for browser scanning
-				os.WriteFile("/tmp/whatsapp-qr.txt", []byte(evt.Code), 0644)
-				htmlQR := fmt.Sprintf(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>WhatsApp QR</title><script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script></head><body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#111"><div style="text-align:center"><h1 style="color:white;font-family:sans-serif">Scan met WhatsApp</h1><canvas id="qr"></canvas><p style="color:#aaa;font-family:sans-serif">Instellingen → Gekoppelde apparaten → Koppel een apparaat</p></div><script>QRCode.toCanvas(document.getElementById('qr'),"%s",{width:400,margin:2},function(e){if(e)console.error(e)})</script></body></html>`, evt.Code)
-				os.WriteFile("/tmp/whatsapp-qr.html", []byte(htmlQR), 0644)
 			} else if evt.Event == "success" {
 				connected <- true
 				break

--- a/whatsapp-bridge/internal/whatsapp/client.go
+++ b/whatsapp-bridge/internal/whatsapp/client.go
@@ -71,7 +71,7 @@ func NewClientWithConfig(logger waLog.Logger, cfg *config.Config) (*Client, erro
 		FullSyncSizeMbLimit:            proto.Uint32(cfg.HistorySyncSizeMB),
 		StorageQuotaMb:                 proto.Uint32(cfg.StorageQuotaMB),
 		InlineInitialPayloadInE2EeMsg:  proto.Bool(true),
-		SupportCallLogHistory:          proto.Bool(false),
+		SupportCallLogHistory:          proto.Bool(true),
 		SupportBotUserAgentChatHistory: proto.Bool(true),
 		SupportCagReactionsAndPolls:    proto.Bool(true),
 		SupportGroupHistory:            proto.Bool(true), // Enable group history
@@ -147,6 +147,10 @@ func (c *Client) Connect() error {
 			if evt.Event == "code" {
 				fmt.Println("\nScan this QR code with your WhatsApp app:")
 				qrterminal.GenerateHalfBlock(evt.Code, qrterminal.L, os.Stdout)
+				// Write QR code string and HTML to /tmp for browser scanning
+				os.WriteFile("/tmp/whatsapp-qr.txt", []byte(evt.Code), 0644)
+				htmlQR := fmt.Sprintf(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>WhatsApp QR</title><script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script></head><body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#111"><div style="text-align:center"><h1 style="color:white;font-family:sans-serif">Scan met WhatsApp</h1><canvas id="qr"></canvas><p style="color:#aaa;font-family:sans-serif">Instellingen → Gekoppelde apparaten → Koppel een apparaat</p></div><script>QRCode.toCanvas(document.getElementById('qr'),"%s",{width:400,margin:2},function(e){if(e)console.error(e)})</script></body></html>`, evt.Code)
+				os.WriteFile("/tmp/whatsapp-qr.html", []byte(htmlQR), 0644)
 			} else if evt.Event == "success" {
 				connected <- true
 				break

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -118,38 +118,43 @@ func main() {
 			// Incoming call — store as a message so it shows up in list_messages
 			callFrom := v.From.User
 			chatJID := v.From.String()
-			callType := "voice call"
-			content := fmt.Sprintf("📞 Incoming %s from %s", callType, callFrom)
 			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
 			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
-			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
-			_ = messageStore.StoreMessage(
-				"call-"+v.CallID, chatJID, callFrom, callFrom,
+			content := fmt.Sprintf("📞 Incoming call from %s", name)
+			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
+				logger.Warnf("Failed to store chat for call: %v", err)
+			}
+			if err := messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, name,
 				content, v.Timestamp, false,
 				"call", "", "", nil, nil, nil, 0,
-			)
+			); err != nil {
+				logger.Warnf("Failed to store call message: %v", err)
+			}
 
 		case *events.CallTerminate:
-			callFrom := v.From.User
-			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", callFrom, v.CallID, v.Reason)
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
 
 		case *events.CallAccept:
-			callFrom := v.From.User
-			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", callFrom, v.CallID)
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
 
 		case *events.CallOfferNotice:
-			// Group call notice
+			// Group call notice — has Media field ("audio" or "video")
 			callFrom := v.From.User
 			chatJID := v.From.String()
-			content := fmt.Sprintf("📞 Group %s call from %s", v.Media, callFrom)
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
 			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
-			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
-			_ = messageStore.StoreMessage(
-				"call-"+v.CallID, chatJID, callFrom, callFrom,
+			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
+				logger.Warnf("Failed to store chat for group call: %v", err)
+			}
+			if err := messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, name,
 				content, v.Timestamp, false,
 				"call", "", "", nil, nil, nil, 0,
-			)
+			); err != nil {
+				logger.Warnf("Failed to store group call message: %v", err)
+			}
 		}
 	})
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
+	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 	"whatsapp-bridge/internal/api"
@@ -58,6 +61,30 @@ func main() {
 	if err != nil {
 		logger.Errorf("Failed to load webhook configs: %v", err)
 		os.Exit(1)
+	}
+
+	// Track active calls for duration calculation and missed/answered status
+	type activeCall struct {
+		ChatJID   string
+		Name      string
+		Timestamp time.Time
+	}
+	var (
+		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
+		activeCallsMu sync.Mutex
+	)
+
+	// resolveCallJID resolves a LID JID to a regular phone number JID for call events
+	resolveCallJID := func(jid types.JID) types.JID {
+		if jid.Server == types.HiddenUserServer {
+			resolved, err := client.Store.GetAltJID(context.Background(), jid)
+			if err == nil && !resolved.IsEmpty() {
+				logger.Infof("[CALL] Resolved LID %s → %s", jid, resolved)
+				return resolved
+			}
+			logger.Warnf("[CALL] Could not resolve LID %s: %v", jid, err)
+		}
+		return jid
 	}
 
 	// Setup event handling for messages and history sync
@@ -115,12 +142,19 @@ func main() {
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
 
 		case *events.CallOffer:
-			// Incoming call — store as a message so it shows up in list_messages
-			callFrom := v.From.User
-			chatJID := v.From.String()
+			// Incoming call — resolve LID to regular JID, store as message
+			resolvedJID := resolveCallJID(v.From)
+			callFrom := resolvedJID.User
+			chatJID := resolvedJID.String()
 			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
-			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming call from %s", name)
+
+			// Track call for duration/status updates
+			activeCallsMu.Lock()
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCallsMu.Unlock()
+
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
 				logger.Warnf("Failed to store chat for call: %v", err)
 			}
@@ -135,16 +169,49 @@ func main() {
 		case *events.CallTerminate:
 			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
 
+			// Update stored call message with duration and status
+			activeCallsMu.Lock()
+			call, exists := activeCalls[v.CallID]
+			if exists {
+				delete(activeCalls, v.CallID)
+			}
+			activeCallsMu.Unlock()
+
+			if exists {
+				duration := v.Timestamp.Sub(call.Timestamp)
+				var content string
+				switch v.Reason {
+				case "timeout", "busy":
+					content = fmt.Sprintf("📞 Missed call from %s", call.Name)
+				default:
+					content = fmt.Sprintf("📞 Call with %s (%s)", call.Name, formatDuration(duration))
+				}
+				// Update the stored message with final status
+				if err := messageStore.StoreMessage(
+					"call-"+v.CallID, call.ChatJID, v.From.User, call.Name,
+					content, call.Timestamp, false,
+					"call", "", "", nil, nil, nil, 0,
+				); err != nil {
+					logger.Warnf("Failed to update call message: %v", err)
+				}
+			}
+
 		case *events.CallAccept:
 			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
 
 		case *events.CallOfferNotice:
 			// Group call notice — has Media field ("audio" or "video")
-			callFrom := v.From.User
-			chatJID := v.From.String()
+			resolvedJID := resolveCallJID(v.From)
+			callFrom := resolvedJID.User
+			chatJID := resolvedJID.String()
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
-			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+
+			activeCallsMu.Lock()
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCallsMu.Unlock()
+
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
 				logger.Warnf("Failed to store chat for group call: %v", err)
 			}
@@ -226,4 +293,19 @@ func main() {
 	fmt.Println("Disconnecting...")
 	// Disconnect client
 	client.Disconnect()
+}
+
+// formatDuration formats a duration as "M:SS" or "H:MM:SS"
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	totalSeconds := int(d.Seconds())
+	hours := totalSeconds / 3600
+	minutes := (totalSeconds % 3600) / 60
+	seconds := totalSeconds % 60
+	if hours > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, seconds)
+	}
+	return fmt.Sprintf("%d:%02d", minutes, seconds)
 }

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -66,6 +66,7 @@ func main() {
 	// Track active calls for duration calculation and missed/answered status
 	type activeCall struct {
 		ChatJID   string
+		Sender    string
 		Name      string
 		Timestamp time.Time
 	}
@@ -73,6 +74,22 @@ func main() {
 		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
 		activeCallsMu sync.Mutex
 	)
+
+	// Cleanup stale calls that never received a terminate/reject event (e.g. network drop)
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			activeCallsMu.Lock()
+			for id, call := range activeCalls {
+				if time.Since(call.Timestamp) > 5*time.Minute {
+					delete(activeCalls, id)
+					logger.Debugf("[CALL] Cleaned up stale call %s", id)
+				}
+			}
+			activeCallsMu.Unlock()
+		}
+	}()
 
 	// resolveCallJID resolves a LID JID to a regular phone number JID for call events
 	resolveCallJID := func(jid types.JID) types.JID {
@@ -146,13 +163,14 @@ func main() {
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
 			chatJID := resolvedJID.String()
-			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
+			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, isFromMe)
 			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming call from %s", name)
 
 			// Track call for duration/status updates
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -160,14 +178,15 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, false,
+				content, v.Timestamp, isFromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store call message: %v", err)
 			}
 
 		case *events.CallTerminate:
-			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", resolvedJID.User, v.CallID, v.Reason)
 
 			// Update stored call message with duration and status
 			activeCallsMu.Lock()
@@ -188,11 +207,33 @@ func main() {
 				}
 				// Update the stored message with final status
 				if err := messageStore.StoreMessage(
-					"call-"+v.CallID, call.ChatJID, v.From.User, call.Name,
+					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
 					content, call.Timestamp, false,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update call message: %v", err)
+				}
+			}
+
+		case *events.CallReject:
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallReject from %s (CallID: %s)", resolvedJID.User, v.CallID)
+
+			activeCallsMu.Lock()
+			call, exists := activeCalls[v.CallID]
+			if exists {
+				delete(activeCalls, v.CallID)
+			}
+			activeCallsMu.Unlock()
+
+			if exists {
+				content := fmt.Sprintf("📞 Missed call from %s", call.Name)
+				if err := messageStore.StoreMessage(
+					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
+					content, call.Timestamp, false,
+					"call", "", "", nil, nil, nil, 0,
+				); err != nil {
+					logger.Warnf("Failed to update rejected call message: %v", err)
 				}
 			}
 
@@ -203,13 +244,25 @@ func main() {
 			// Group call notice — has Media field ("audio" or "video")
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			chatJID := resolvedJID.String()
-			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
-			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+
+			// Use GroupJID as chat for group calls, otherwise use caller's JID
+			var chatJID string
+			var chatResolvedJID types.JID
+			if !v.GroupJID.IsEmpty() {
+				chatJID = v.GroupJID.String()
+				chatResolvedJID = v.GroupJID
+			} else {
+				chatJID = resolvedJID.String()
+				chatResolvedJID = resolvedJID
+			}
+
+			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s, Group: %s)", callFrom, v.CallID, v.Media, chatJID)
+			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
+			content := fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
 
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -217,7 +270,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, false,
+				content, v.Timestamp, isFromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store group call message: %v", err)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -69,6 +69,7 @@ func main() {
 		Sender    string
 		Name      string
 		Timestamp time.Time
+		IsFromMe  bool
 	}
 	var (
 		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
@@ -96,12 +97,29 @@ func main() {
 		if jid.Server == types.HiddenUserServer {
 			resolved, err := client.Store.GetAltJID(context.Background(), jid)
 			if err == nil && !resolved.IsEmpty() {
-				logger.Infof("[CALL] Resolved LID %s → %s", jid, resolved)
+				logger.Debugf("[CALL] Resolved LID %s → %s", jid, resolved)
 				return resolved
 			}
 			logger.Warnf("[CALL] Could not resolve LID %s: %v", jid, err)
 		}
 		return jid
+	}
+
+	// isCallFromMe checks if a call was initiated by us. Compares both the original
+	// and resolved JID against our own ID, plus the CallCreator field, to handle
+	// LID vs phone-number JID mismatches on multi-device.
+	isCallFromMe := func(from types.JID, resolvedFrom types.JID, callCreator types.JID) bool {
+		if client.Store.ID == nil {
+			return false
+		}
+		ownUser := client.Store.ID.ToNonAD().User
+		if from.User == ownUser || resolvedFrom.User == ownUser {
+			return true
+		}
+		if !callCreator.IsEmpty() && callCreator.User == ownUser {
+			return true
+		}
+		return false
 	}
 
 	// Setup event handling for messages and history sync
@@ -159,18 +177,33 @@ func main() {
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
 
 		case *events.CallOffer:
-			// Incoming call — resolve LID to regular JID, store as message
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			chatJID := resolvedJID.String()
-			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
-			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, isFromMe)
-			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming call from %s", name)
+			fromMe := isCallFromMe(v.From, resolvedJID, v.CallCreator)
+
+			// Use GroupJID as chat for group calls, otherwise use caller's JID
+			var chatJID string
+			var chatResolvedJID types.JID
+			if !v.GroupJID.IsEmpty() {
+				chatJID = v.GroupJID.String()
+				chatResolvedJID = v.GroupJID
+			} else {
+				chatJID = resolvedJID.String()
+				chatResolvedJID = resolvedJID
+			}
+
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, fromMe)
+			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
+			var content string
+			if fromMe {
+				content = fmt.Sprintf("📞 Outgoing call to %s", name)
+			} else {
+				content = fmt.Sprintf("📞 Incoming call from %s", name)
+			}
 
 			// Track call for duration/status updates
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp, IsFromMe: fromMe}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -178,7 +211,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, isFromMe,
+				content, v.Timestamp, fromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store call message: %v", err)
@@ -208,7 +241,7 @@ func main() {
 				// Update the stored message with final status
 				if err := messageStore.StoreMessage(
 					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
-					content, call.Timestamp, false,
+					content, call.Timestamp, call.IsFromMe,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update call message: %v", err)
@@ -230,7 +263,7 @@ func main() {
 				content := fmt.Sprintf("📞 Missed call from %s", call.Name)
 				if err := messageStore.StoreMessage(
 					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
-					content, call.Timestamp, false,
+					content, call.Timestamp, call.IsFromMe,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update rejected call message: %v", err)
@@ -238,13 +271,20 @@ func main() {
 			}
 
 		case *events.CallAccept:
-			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", resolvedJID.User, v.CallID)
+			// Update timestamp so duration is measured from accept (not ring start)
+			activeCallsMu.Lock()
+			if call, exists := activeCalls[v.CallID]; exists {
+				call.Timestamp = v.Timestamp
+			}
+			activeCallsMu.Unlock()
 
 		case *events.CallOfferNotice:
 			// Group call notice — has Media field ("audio" or "video")
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+			fromMe := isCallFromMe(v.From, resolvedJID, v.CallCreator)
 
 			// Use GroupJID as chat for group calls, otherwise use caller's JID
 			var chatJID string
@@ -259,10 +299,15 @@ func main() {
 
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s, Group: %s)", callFrom, v.CallID, v.Media, chatJID)
 			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
+			var content string
+			if fromMe {
+				content = fmt.Sprintf("📞 Outgoing %s call to %s", v.Media, name)
+			} else {
+				content = fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
+			}
 
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp, IsFromMe: fromMe}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -270,7 +315,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, isFromMe,
+				content, v.Timestamp, fromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store group call message: %v", err)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -113,6 +113,43 @@ func main() {
 		case *events.Disconnected:
 			client.MarkDisconnected()
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
+
+		case *events.CallOffer:
+			// Incoming call — store as a message so it shows up in list_messages
+			callFrom := v.From.User
+			chatJID := v.From.String()
+			callType := "voice call"
+			content := fmt.Sprintf("📞 Incoming %s from %s", callType, callFrom)
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
+			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
+			_ = messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, callFrom,
+				content, v.Timestamp, false,
+				"call", "", "", nil, nil, nil, 0,
+			)
+
+		case *events.CallTerminate:
+			callFrom := v.From.User
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", callFrom, v.CallID, v.Reason)
+
+		case *events.CallAccept:
+			callFrom := v.From.User
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", callFrom, v.CallID)
+
+		case *events.CallOfferNotice:
+			// Group call notice
+			callFrom := v.From.User
+			chatJID := v.From.String()
+			content := fmt.Sprintf("📞 Group %s call from %s", v.Media, callFrom)
+			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
+			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
+			_ = messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, callFrom,
+				content, v.Timestamp, false,
+				"call", "", "", nil, nil, nil, 0,
+			)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Handle `CallOffer`, `CallAccept`, `CallTerminate`, and `CallOfferNotice` events from whatsmeow
- Incoming calls are stored in the messages database with `media_type: "call"`, making them visible via `list_messages`
- Enable `SupportCallLogHistory` in `HistorySyncConfig` so call logs are included in history sync

## Motivation
WhatsApp calls were completely invisible to MCP clients — `list_messages` only returned text/media messages. This meant any conversation context from calls was lost. With this change, incoming calls appear as messages with a 📞 prefix, so MCP tools can see when calls happened.

## Changes
- **`client.go`**: Set `SupportCallLogHistory: true` in `DeviceProps.HistorySyncConfig`
- **`main.go`**: Add event handlers for `CallOffer` (stores as message), `CallAccept` (logs), `CallTerminate` (logs), and `CallOfferNotice` (stores group calls as message)

## Test plan
- [x] Verified `CallOffer` event is received when someone calls via WhatsApp
- [x] Verified call is stored in SQLite and visible via `list_messages` with `media_type: "call"`
- [x] Verified `CallAccept` and `CallTerminate` events are logged