### PR TITLE
Improve contact name resolution in GetChatName

### DIFF
--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -86,7 +86,7 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		// Try all available name fields from the contact store
 		// Priority: FullName > PushName > FirstName > BusinessName
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
-		if err == nil {
+		if err == nil && contact.Found {
 			switch {
 			case contact.FullName != "":
 				name = contact.FullName

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -13,10 +13,12 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-// isPhoneNumber checks if a string looks like a phone number (digits only, 7-15 chars)
-var isPhoneNumber = regexp.MustCompile(`^\d{7,15}$`).MatchString
+// isPhoneNumber checks if a string looks like a phone number (optional + prefix, 5-15 digits).
+// Used to detect cached chat names that are just phone numbers, so we can try to resolve a real name.
+var isPhoneNumber = regexp.MustCompile(`^\+?\d{5,15}$`).MatchString
 
-// GetChatName determines the appropriate name for a chat based on JID and other info
+// GetChatName determines the appropriate name for a chat based on JID and other info.
+// Note: callers are responsible for persisting the returned name via StoreChat.
 func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string) string {
 	// First, check if chat already exists in database with a name
 	var existingName string
@@ -82,6 +84,7 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		c.logger.Infof("Getting name for contact: %s", chatJID)
 
 		// Try all available name fields from the contact store
+		// Priority: FullName > PushName > FirstName > BusinessName
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
 		if err == nil {
 			switch {

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"time"
 
 	"whatsapp-bridge/internal/database"
@@ -12,13 +13,16 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
+// isPhoneNumber checks if a string looks like a phone number (digits only, 7-15 chars)
+var isPhoneNumber = regexp.MustCompile(`^\d{7,15}$`).MatchString
+
 // GetChatName determines the appropriate name for a chat based on JID and other info
 func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string) string {
 	// First, check if chat already exists in database with a name
 	var existingName string
 	err := messageStore.GetDB().QueryRow("SELECT name FROM chats WHERE jid = ?", chatJID).Scan(&existingName)
-	if err == nil && existingName != "" {
-		// Chat exists with a name, use that
+	if err == nil && existingName != "" && !isPhoneNumber(existingName) {
+		// Chat exists with a real name (not just a phone number), use that
 		c.logger.Infof("Using existing chat name for %s: %s", chatJID, existingName)
 		return existingName
 	}
@@ -77,16 +81,26 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		// This is an individual contact
 		c.logger.Infof("Getting name for contact: %s", chatJID)
 
-		// Just use contact info (full name)
+		// Try all available name fields from the contact store
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
-		if err == nil && contact.FullName != "" {
-			name = contact.FullName
-		} else if sender != "" {
-			// Fallback to sender
-			name = sender
-		} else {
-			// Last fallback to JID
-			name = jid.User
+		if err == nil {
+			switch {
+			case contact.FullName != "":
+				name = contact.FullName
+			case contact.PushName != "":
+				name = contact.PushName
+			case contact.FirstName != "":
+				name = contact.FirstName
+			case contact.BusinessName != "":
+				name = contact.BusinessName
+			}
+		}
+		if name == "" {
+			if sender != "" {
+				name = sender
+			} else {
+				name = jid.User
+			}
 		}
 
 		c.logger.Infof("Using contact name: %s", name)


### PR DESCRIPTION
## Summary
- Try all `ContactInfo` fields (`FullName` → `PushName` → `FirstName` → `BusinessName`) instead of only `FullName` with fallback to phone number
- Skip cached chat name when it's just a phone number, so a real name from the contact store can replace it

## Problem
When a contact has no `FullName` in the whatsmeow contact store but does have a `PushName`, `GetChatName` falls back to showing the raw phone number. The cached chat name in the database also prevents resolution — once stored as a phone number, it stays that way even when a real name becomes available.

## Test plan
- [x] Verified that contacts with `PushName` but no `FullName` now resolve correctly
- [x] Existing chats stored with phone numbers get updated when a real name is found
- [x] Contacts with no name fields still fall back to phone number as before