### PR TITLE
Accept WHATSAPP_API_KEY in MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Delivery: async with exponential backoff, HMAC-SHA256 signatures
 
 ## Environment Variables
 - `BRIDGE_HOST`: Go bridge hostname (default: localhost, set to container name in docker)
+- `API_KEY` or `WHATSAPP_API_KEY`: Bridge API secret for the Python MCP server
 - `GRADIO`: Enable/disable Gradio UI (true/false)
 - `DEBUG`: Enable debug logging
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ An extended Model Context Protocol (MCP) server for WhatsApp with **41 tools** -
 | Newsletters | - | ✅ |
 | Webhooks | - | ✅ |
 | Custom Nicknames | - | ✅ |
+| Call Event Tracking | - | ✅ |
+| Contact Name Resolution | - | ✅ |
 
 ## Architecture
 
@@ -134,6 +136,12 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
 | `unfollow_newsletter` | Unfollow channel |
 | `create_newsletter` | Create new channel |
 
+### Call Events
+Incoming and outgoing WhatsApp calls are automatically stored as messages, including:
+- Call type (voice/video), duration, and missed/answered status
+- LID-to-phone JID resolution for accurate caller identification
+- `isFromMe` detection for distinguishing incoming vs outgoing calls
+
 ## Webhook System
 
 Real-time HTTP webhooks for incoming messages with:
@@ -211,7 +219,8 @@ docker-compose logs -f whatsapp-bridge
 **Fork chain:**
 - [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) - Original MCP server (12 tools)
 - [AdamRussak/whatsapp-mcp](https://github.com/AdamRussak/whatsapp-mcp) - Added webhooks, container split, webhook UI
-- This repo - Added reactions, edit/delete, groups, polls, presence, newsletters (41 tools)
+- [FelixIsaac/whatsapp-mcp-extended](https://github.com/FelixIsaac/whatsapp-mcp-extended) - Added reactions, edit/delete, groups, polls, presence, newsletters (41 tools)
+- This repo - Added call event tracking, improved contact name resolution
 
 **Libraries:**
 - [whatsmeow](https://github.com/tulir/whatsmeow) - Go WhatsApp Web API

--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
       "command": "uv",
       "args": ["run", "--directory", "/path/to/whatsapp-mcp-extended/whatsapp-mcp-server", "python", "main.py"],
       "env": {
-        "API_KEY": "your-bridge-api-key",
+        "WHATSAPP_API_KEY": "your-bridge-api-key",
         "BRIDGE_HOST": "localhost:8080"
       }
     }
   }
 }
 ```
+
+`API_KEY` is also supported for compatibility with the bridge and older configs.
 
 Set `BRIDGE_HOST` to `hostname:port` matching your bridge configuration.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with **41 tools** -
 ### Docker (Recommended)
 
 ```bash
-git clone https://github.com/felixisaac/whatsapp-mcp-extended
+git clone https://github.com/kasperpeulen/whatsapp-mcp-extended
 cd whatsapp-mcp-extended
 
 docker network create n8n_n8n_traefik_network
@@ -63,11 +63,17 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
   "mcpServers": {
     "whatsapp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/whatsapp-mcp-extended/whatsapp-mcp-server", "python", "main.py"]
+      "args": ["run", "--directory", "/path/to/whatsapp-mcp-extended/whatsapp-mcp-server", "python", "main.py"],
+      "env": {
+        "API_KEY": "your-bridge-api-key",
+        "BRIDGE_HOST": "localhost:8080"
+      }
     }
   }
 }
 ```
+
+Set `BRIDGE_HOST` to `hostname:port` matching your bridge configuration.
 
 ## MCP Tools (41 Total)
 

--- a/whatsapp-bridge/internal/whatsapp/client.go
+++ b/whatsapp-bridge/internal/whatsapp/client.go
@@ -147,10 +147,6 @@ func (c *Client) Connect() error {
 			if evt.Event == "code" {
 				fmt.Println("\nScan this QR code with your WhatsApp app:")
 				qrterminal.GenerateHalfBlock(evt.Code, qrterminal.L, os.Stdout)
-				// Write QR code string and HTML to /tmp for browser scanning
-				os.WriteFile("/tmp/whatsapp-qr.txt", []byte(evt.Code), 0644)
-				htmlQR := fmt.Sprintf(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>WhatsApp QR</title><script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script></head><body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#111"><div style="text-align:center"><h1 style="color:white;font-family:sans-serif">Scan met WhatsApp</h1><canvas id="qr"></canvas><p style="color:#aaa;font-family:sans-serif">Instellingen → Gekoppelde apparaten → Koppel een apparaat</p></div><script>QRCode.toCanvas(document.getElementById('qr'),"%s",{width:400,margin:2},function(e){if(e)console.error(e)})</script></body></html>`, evt.Code)
-				os.WriteFile("/tmp/whatsapp-qr.html", []byte(htmlQR), 0644)
 			} else if evt.Event == "success" {
 				connected <- true
 				break

--- a/whatsapp-bridge/internal/whatsapp/client.go
+++ b/whatsapp-bridge/internal/whatsapp/client.go
@@ -71,7 +71,7 @@ func NewClientWithConfig(logger waLog.Logger, cfg *config.Config) (*Client, erro
 		FullSyncSizeMbLimit:            proto.Uint32(cfg.HistorySyncSizeMB),
 		StorageQuotaMb:                 proto.Uint32(cfg.StorageQuotaMB),
 		InlineInitialPayloadInE2EeMsg:  proto.Bool(true),
-		SupportCallLogHistory:          proto.Bool(false),
+		SupportCallLogHistory:          proto.Bool(true),
 		SupportBotUserAgentChatHistory: proto.Bool(true),
 		SupportCagReactionsAndPolls:    proto.Bool(true),
 		SupportGroupHistory:            proto.Bool(true), // Enable group history
@@ -147,6 +147,10 @@ func (c *Client) Connect() error {
 			if evt.Event == "code" {
 				fmt.Println("\nScan this QR code with your WhatsApp app:")
 				qrterminal.GenerateHalfBlock(evt.Code, qrterminal.L, os.Stdout)
+				// Write QR code string and HTML to /tmp for browser scanning
+				os.WriteFile("/tmp/whatsapp-qr.txt", []byte(evt.Code), 0644)
+				htmlQR := fmt.Sprintf(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>WhatsApp QR</title><script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script></head><body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#111"><div style="text-align:center"><h1 style="color:white;font-family:sans-serif">Scan met WhatsApp</h1><canvas id="qr"></canvas><p style="color:#aaa;font-family:sans-serif">Instellingen → Gekoppelde apparaten → Koppel een apparaat</p></div><script>QRCode.toCanvas(document.getElementById('qr'),"%s",{width:400,margin:2},function(e){if(e)console.error(e)})</script></body></html>`, evt.Code)
+				os.WriteFile("/tmp/whatsapp-qr.html", []byte(htmlQR), 0644)
 			} else if evt.Event == "success" {
 				connected <- true
 				break

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -86,7 +86,7 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		// Try all available name fields from the contact store
 		// Priority: FullName > PushName > FirstName > BusinessName
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
-		if err == nil {
+		if err == nil && contact.Found {
 			switch {
 			case contact.FullName != "":
 				name = contact.FullName

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -13,10 +13,12 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-// isPhoneNumber checks if a string looks like a phone number (digits only, 7-15 chars)
-var isPhoneNumber = regexp.MustCompile(`^\d{7,15}$`).MatchString
+// isPhoneNumber checks if a string looks like a phone number (optional + prefix, 5-15 digits).
+// Used to detect cached chat names that are just phone numbers, so we can try to resolve a real name.
+var isPhoneNumber = regexp.MustCompile(`^\+?\d{5,15}$`).MatchString
 
-// GetChatName determines the appropriate name for a chat based on JID and other info
+// GetChatName determines the appropriate name for a chat based on JID and other info.
+// Note: callers are responsible for persisting the returned name via StoreChat.
 func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string) string {
 	// First, check if chat already exists in database with a name
 	var existingName string
@@ -82,6 +84,7 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		c.logger.Infof("Getting name for contact: %s", chatJID)
 
 		// Try all available name fields from the contact store
+		// Priority: FullName > PushName > FirstName > BusinessName
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
 		if err == nil {
 			switch {

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"time"
 
 	"whatsapp-bridge/internal/database"
@@ -12,13 +13,16 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
+// isPhoneNumber checks if a string looks like a phone number (digits only, 7-15 chars)
+var isPhoneNumber = regexp.MustCompile(`^\d{7,15}$`).MatchString
+
 // GetChatName determines the appropriate name for a chat based on JID and other info
 func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID, chatJID string, conversation interface{}, sender string) string {
 	// First, check if chat already exists in database with a name
 	var existingName string
 	err := messageStore.GetDB().QueryRow("SELECT name FROM chats WHERE jid = ?", chatJID).Scan(&existingName)
-	if err == nil && existingName != "" {
-		// Chat exists with a name, use that
+	if err == nil && existingName != "" && !isPhoneNumber(existingName) {
+		// Chat exists with a real name (not just a phone number), use that
 		c.logger.Infof("Using existing chat name for %s: %s", chatJID, existingName)
 		return existingName
 	}
@@ -77,16 +81,26 @@ func (c *Client) GetChatName(messageStore *database.MessageStore, jid types.JID,
 		// This is an individual contact
 		c.logger.Infof("Getting name for contact: %s", chatJID)
 
-		// Just use contact info (full name)
+		// Try all available name fields from the contact store
 		contact, err := c.Store.Contacts.GetContact(context.Background(), jid)
-		if err == nil && contact.FullName != "" {
-			name = contact.FullName
-		} else if sender != "" {
-			// Fallback to sender
-			name = sender
-		} else {
-			// Last fallback to JID
-			name = jid.User
+		if err == nil {
+			switch {
+			case contact.FullName != "":
+				name = contact.FullName
+			case contact.PushName != "":
+				name = contact.PushName
+			case contact.FirstName != "":
+				name = contact.FirstName
+			case contact.BusinessName != "":
+				name = contact.BusinessName
+			}
+		}
+		if name == "" {
+			if sender != "" {
+				name = sender
+			} else {
+				name = jid.User
+			}
 		}
 
 		c.logger.Infof("Using contact name: %s", name)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -118,38 +118,43 @@ func main() {
 			// Incoming call — store as a message so it shows up in list_messages
 			callFrom := v.From.User
 			chatJID := v.From.String()
-			callType := "voice call"
-			content := fmt.Sprintf("📞 Incoming %s from %s", callType, callFrom)
 			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
 			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
-			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
-			_ = messageStore.StoreMessage(
-				"call-"+v.CallID, chatJID, callFrom, callFrom,
+			content := fmt.Sprintf("📞 Incoming call from %s", name)
+			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
+				logger.Warnf("Failed to store chat for call: %v", err)
+			}
+			if err := messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, name,
 				content, v.Timestamp, false,
 				"call", "", "", nil, nil, nil, 0,
-			)
+			); err != nil {
+				logger.Warnf("Failed to store call message: %v", err)
+			}
 
 		case *events.CallTerminate:
-			callFrom := v.From.User
-			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", callFrom, v.CallID, v.Reason)
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
 
 		case *events.CallAccept:
-			callFrom := v.From.User
-			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", callFrom, v.CallID)
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
 
 		case *events.CallOfferNotice:
-			// Group call notice
+			// Group call notice — has Media field ("audio" or "video")
 			callFrom := v.From.User
 			chatJID := v.From.String()
-			content := fmt.Sprintf("📞 Group %s call from %s", v.Media, callFrom)
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
 			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
-			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
-			_ = messageStore.StoreMessage(
-				"call-"+v.CallID, chatJID, callFrom, callFrom,
+			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
+				logger.Warnf("Failed to store chat for group call: %v", err)
+			}
+			if err := messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, name,
 				content, v.Timestamp, false,
 				"call", "", "", nil, nil, nil, 0,
-			)
+			); err != nil {
+				logger.Warnf("Failed to store group call message: %v", err)
+			}
 		}
 	})
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
+	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 	"whatsapp-bridge/internal/api"
@@ -58,6 +61,30 @@ func main() {
 	if err != nil {
 		logger.Errorf("Failed to load webhook configs: %v", err)
 		os.Exit(1)
+	}
+
+	// Track active calls for duration calculation and missed/answered status
+	type activeCall struct {
+		ChatJID   string
+		Name      string
+		Timestamp time.Time
+	}
+	var (
+		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
+		activeCallsMu sync.Mutex
+	)
+
+	// resolveCallJID resolves a LID JID to a regular phone number JID for call events
+	resolveCallJID := func(jid types.JID) types.JID {
+		if jid.Server == types.HiddenUserServer {
+			resolved, err := client.Store.GetAltJID(context.Background(), jid)
+			if err == nil && !resolved.IsEmpty() {
+				logger.Infof("[CALL] Resolved LID %s → %s", jid, resolved)
+				return resolved
+			}
+			logger.Warnf("[CALL] Could not resolve LID %s: %v", jid, err)
+		}
+		return jid
 	}
 
 	// Setup event handling for messages and history sync
@@ -115,12 +142,19 @@ func main() {
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
 
 		case *events.CallOffer:
-			// Incoming call — store as a message so it shows up in list_messages
-			callFrom := v.From.User
-			chatJID := v.From.String()
+			// Incoming call — resolve LID to regular JID, store as message
+			resolvedJID := resolveCallJID(v.From)
+			callFrom := resolvedJID.User
+			chatJID := resolvedJID.String()
 			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
-			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming call from %s", name)
+
+			// Track call for duration/status updates
+			activeCallsMu.Lock()
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCallsMu.Unlock()
+
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
 				logger.Warnf("Failed to store chat for call: %v", err)
 			}
@@ -135,16 +169,49 @@ func main() {
 		case *events.CallTerminate:
 			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
 
+			// Update stored call message with duration and status
+			activeCallsMu.Lock()
+			call, exists := activeCalls[v.CallID]
+			if exists {
+				delete(activeCalls, v.CallID)
+			}
+			activeCallsMu.Unlock()
+
+			if exists {
+				duration := v.Timestamp.Sub(call.Timestamp)
+				var content string
+				switch v.Reason {
+				case "timeout", "busy":
+					content = fmt.Sprintf("📞 Missed call from %s", call.Name)
+				default:
+					content = fmt.Sprintf("📞 Call with %s (%s)", call.Name, formatDuration(duration))
+				}
+				// Update the stored message with final status
+				if err := messageStore.StoreMessage(
+					"call-"+v.CallID, call.ChatJID, v.From.User, call.Name,
+					content, call.Timestamp, false,
+					"call", "", "", nil, nil, nil, 0,
+				); err != nil {
+					logger.Warnf("Failed to update call message: %v", err)
+				}
+			}
+
 		case *events.CallAccept:
 			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
 
 		case *events.CallOfferNotice:
 			// Group call notice — has Media field ("audio" or "video")
-			callFrom := v.From.User
-			chatJID := v.From.String()
+			resolvedJID := resolveCallJID(v.From)
+			callFrom := resolvedJID.User
+			chatJID := resolvedJID.String()
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
-			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+
+			activeCallsMu.Lock()
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCallsMu.Unlock()
+
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
 				logger.Warnf("Failed to store chat for group call: %v", err)
 			}
@@ -226,4 +293,19 @@ func main() {
 	fmt.Println("Disconnecting...")
 	// Disconnect client
 	client.Disconnect()
+}
+
+// formatDuration formats a duration as "M:SS" or "H:MM:SS"
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	totalSeconds := int(d.Seconds())
+	hours := totalSeconds / 3600
+	minutes := (totalSeconds % 3600) / 60
+	seconds := totalSeconds % 60
+	if hours > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, seconds)
+	}
+	return fmt.Sprintf("%d:%02d", minutes, seconds)
 }

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -66,6 +66,7 @@ func main() {
 	// Track active calls for duration calculation and missed/answered status
 	type activeCall struct {
 		ChatJID   string
+		Sender    string
 		Name      string
 		Timestamp time.Time
 	}
@@ -73,6 +74,22 @@ func main() {
 		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
 		activeCallsMu sync.Mutex
 	)
+
+	// Cleanup stale calls that never received a terminate/reject event (e.g. network drop)
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			activeCallsMu.Lock()
+			for id, call := range activeCalls {
+				if time.Since(call.Timestamp) > 5*time.Minute {
+					delete(activeCalls, id)
+					logger.Debugf("[CALL] Cleaned up stale call %s", id)
+				}
+			}
+			activeCallsMu.Unlock()
+		}
+	}()
 
 	// resolveCallJID resolves a LID JID to a regular phone number JID for call events
 	resolveCallJID := func(jid types.JID) types.JID {
@@ -146,13 +163,14 @@ func main() {
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
 			chatJID := resolvedJID.String()
-			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
+			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, isFromMe)
 			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
 			content := fmt.Sprintf("📞 Incoming call from %s", name)
 
 			// Track call for duration/status updates
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -160,14 +178,15 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, false,
+				content, v.Timestamp, isFromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store call message: %v", err)
 			}
 
 		case *events.CallTerminate:
-			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", v.From.User, v.CallID, v.Reason)
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", resolvedJID.User, v.CallID, v.Reason)
 
 			// Update stored call message with duration and status
 			activeCallsMu.Lock()
@@ -188,11 +207,33 @@ func main() {
 				}
 				// Update the stored message with final status
 				if err := messageStore.StoreMessage(
-					"call-"+v.CallID, call.ChatJID, v.From.User, call.Name,
+					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
 					content, call.Timestamp, false,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update call message: %v", err)
+				}
+			}
+
+		case *events.CallReject:
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallReject from %s (CallID: %s)", resolvedJID.User, v.CallID)
+
+			activeCallsMu.Lock()
+			call, exists := activeCalls[v.CallID]
+			if exists {
+				delete(activeCalls, v.CallID)
+			}
+			activeCallsMu.Unlock()
+
+			if exists {
+				content := fmt.Sprintf("📞 Missed call from %s", call.Name)
+				if err := messageStore.StoreMessage(
+					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
+					content, call.Timestamp, false,
+					"call", "", "", nil, nil, nil, 0,
+				); err != nil {
+					logger.Warnf("Failed to update rejected call message: %v", err)
 				}
 			}
 
@@ -203,13 +244,25 @@ func main() {
 			// Group call notice — has Media field ("audio" or "video")
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			chatJID := resolvedJID.String()
-			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
-			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming group %s call from %s", v.Media, name)
+			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+
+			// Use GroupJID as chat for group calls, otherwise use caller's JID
+			var chatJID string
+			var chatResolvedJID types.JID
+			if !v.GroupJID.IsEmpty() {
+				chatJID = v.GroupJID.String()
+				chatResolvedJID = v.GroupJID
+			} else {
+				chatJID = resolvedJID.String()
+				chatResolvedJID = resolvedJID
+			}
+
+			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s, Group: %s)", callFrom, v.CallID, v.Media, chatJID)
+			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
+			content := fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
 
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -217,7 +270,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, false,
+				content, v.Timestamp, isFromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store group call message: %v", err)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -69,6 +69,7 @@ func main() {
 		Sender    string
 		Name      string
 		Timestamp time.Time
+		IsFromMe  bool
 	}
 	var (
 		activeCalls   = make(map[string]*activeCall) // CallID -> activeCall
@@ -96,12 +97,29 @@ func main() {
 		if jid.Server == types.HiddenUserServer {
 			resolved, err := client.Store.GetAltJID(context.Background(), jid)
 			if err == nil && !resolved.IsEmpty() {
-				logger.Infof("[CALL] Resolved LID %s → %s", jid, resolved)
+				logger.Debugf("[CALL] Resolved LID %s → %s", jid, resolved)
 				return resolved
 			}
 			logger.Warnf("[CALL] Could not resolve LID %s: %v", jid, err)
 		}
 		return jid
+	}
+
+	// isCallFromMe checks if a call was initiated by us. Compares both the original
+	// and resolved JID against our own ID, plus the CallCreator field, to handle
+	// LID vs phone-number JID mismatches on multi-device.
+	isCallFromMe := func(from types.JID, resolvedFrom types.JID, callCreator types.JID) bool {
+		if client.Store.ID == nil {
+			return false
+		}
+		ownUser := client.Store.ID.ToNonAD().User
+		if from.User == ownUser || resolvedFrom.User == ownUser {
+			return true
+		}
+		if !callCreator.IsEmpty() && callCreator.User == ownUser {
+			return true
+		}
+		return false
 	}
 
 	// Setup event handling for messages and history sync
@@ -159,18 +177,33 @@ func main() {
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
 
 		case *events.CallOffer:
-			// Incoming call — resolve LID to regular JID, store as message
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			chatJID := resolvedJID.String()
-			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
-			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, isFromMe)
-			name := client.GetChatName(messageStore, resolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming call from %s", name)
+			fromMe := isCallFromMe(v.From, resolvedJID, v.CallCreator)
+
+			// Use GroupJID as chat for group calls, otherwise use caller's JID
+			var chatJID string
+			var chatResolvedJID types.JID
+			if !v.GroupJID.IsEmpty() {
+				chatJID = v.GroupJID.String()
+				chatResolvedJID = v.GroupJID
+			} else {
+				chatJID = resolvedJID.String()
+				chatResolvedJID = resolvedJID
+			}
+
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s, isFromMe: %v)", callFrom, v.CallID, fromMe)
+			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
+			var content string
+			if fromMe {
+				content = fmt.Sprintf("📞 Outgoing call to %s", name)
+			} else {
+				content = fmt.Sprintf("📞 Incoming call from %s", name)
+			}
 
 			// Track call for duration/status updates
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp, IsFromMe: fromMe}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -178,7 +211,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, isFromMe,
+				content, v.Timestamp, fromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store call message: %v", err)
@@ -208,7 +241,7 @@ func main() {
 				// Update the stored message with final status
 				if err := messageStore.StoreMessage(
 					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
-					content, call.Timestamp, false,
+					content, call.Timestamp, call.IsFromMe,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update call message: %v", err)
@@ -230,7 +263,7 @@ func main() {
 				content := fmt.Sprintf("📞 Missed call from %s", call.Name)
 				if err := messageStore.StoreMessage(
 					"call-"+v.CallID, call.ChatJID, call.Sender, call.Name,
-					content, call.Timestamp, false,
+					content, call.Timestamp, call.IsFromMe,
 					"call", "", "", nil, nil, nil, 0,
 				); err != nil {
 					logger.Warnf("Failed to update rejected call message: %v", err)
@@ -238,13 +271,20 @@ func main() {
 			}
 
 		case *events.CallAccept:
-			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", v.From.User, v.CallID)
+			resolvedJID := resolveCallJID(v.From)
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", resolvedJID.User, v.CallID)
+			// Update timestamp so duration is measured from accept (not ring start)
+			activeCallsMu.Lock()
+			if call, exists := activeCalls[v.CallID]; exists {
+				call.Timestamp = v.Timestamp
+			}
+			activeCallsMu.Unlock()
 
 		case *events.CallOfferNotice:
 			// Group call notice — has Media field ("audio" or "video")
 			resolvedJID := resolveCallJID(v.From)
 			callFrom := resolvedJID.User
-			isFromMe := client.Store.ID != nil && resolvedJID.User == client.Store.ID.User
+			fromMe := isCallFromMe(v.From, resolvedJID, v.CallCreator)
 
 			// Use GroupJID as chat for group calls, otherwise use caller's JID
 			var chatJID string
@@ -259,10 +299,15 @@ func main() {
 
 			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s, Group: %s)", callFrom, v.CallID, v.Media, chatJID)
 			name := client.GetChatName(messageStore, chatResolvedJID, chatJID, nil, callFrom)
-			content := fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
+			var content string
+			if fromMe {
+				content = fmt.Sprintf("📞 Outgoing %s call to %s", v.Media, name)
+			} else {
+				content = fmt.Sprintf("📞 Incoming %s call from %s", v.Media, name)
+			}
 
 			activeCallsMu.Lock()
-			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp}
+			activeCalls[v.CallID] = &activeCall{ChatJID: chatJID, Sender: callFrom, Name: name, Timestamp: v.Timestamp, IsFromMe: fromMe}
 			activeCallsMu.Unlock()
 
 			if err := messageStore.StoreChat(chatJID, name, v.Timestamp); err != nil {
@@ -270,7 +315,7 @@ func main() {
 			}
 			if err := messageStore.StoreMessage(
 				"call-"+v.CallID, chatJID, callFrom, name,
-				content, v.Timestamp, isFromMe,
+				content, v.Timestamp, fromMe,
 				"call", "", "", nil, nil, nil, 0,
 			); err != nil {
 				logger.Warnf("Failed to store group call message: %v", err)

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -113,6 +113,43 @@ func main() {
 		case *events.Disconnected:
 			client.MarkDisconnected()
 			logger.Warnf("⚠ Disconnected from WhatsApp - attempting reconnect")
+
+		case *events.CallOffer:
+			// Incoming call — store as a message so it shows up in list_messages
+			callFrom := v.From.User
+			chatJID := v.From.String()
+			callType := "voice call"
+			content := fmt.Sprintf("📞 Incoming %s from %s", callType, callFrom)
+			logger.Infof("[CALL] CallOffer from %s (CallID: %s)", callFrom, v.CallID)
+			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
+			_ = messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, callFrom,
+				content, v.Timestamp, false,
+				"call", "", "", nil, nil, nil, 0,
+			)
+
+		case *events.CallTerminate:
+			callFrom := v.From.User
+			logger.Infof("[CALL] CallTerminate from %s (CallID: %s, Reason: %s)", callFrom, v.CallID, v.Reason)
+
+		case *events.CallAccept:
+			callFrom := v.From.User
+			logger.Infof("[CALL] CallAccept from %s (CallID: %s)", callFrom, v.CallID)
+
+		case *events.CallOfferNotice:
+			// Group call notice
+			callFrom := v.From.User
+			chatJID := v.From.String()
+			content := fmt.Sprintf("📞 Group %s call from %s", v.Media, callFrom)
+			logger.Infof("[CALL] CallOfferNotice from %s (CallID: %s, Media: %s)", callFrom, v.CallID, v.Media)
+			name := client.GetChatName(messageStore, v.From, chatJID, nil, callFrom)
+			_ = messageStore.StoreChat(chatJID, name, v.Timestamp)
+			_ = messageStore.StoreMessage(
+				"call-"+v.CallID, chatJID, callFrom, callFrom,
+				content, v.Timestamp, false,
+				"call", "", "", nil, nil, nil, 0,
+			)
 		}
 	})
 

--- a/whatsapp-mcp-server/lib/bridge.py
+++ b/whatsapp-mcp-server/lib/bridge.py
@@ -27,8 +27,9 @@ class BridgeError(Exception):
 def _get_headers() -> dict[str, str]:
     """Get request headers including API key if configured."""
     headers = {"Content-Type": "application/json"}
-    api_key = os.getenv("API_KEY")
-    logger.info(f"[BRIDGE-HEADERS] API_KEY loaded: {bool(api_key)}")
+    # Accept both names so clients can forward an app-specific secret without renaming it.
+    api_key = os.getenv("API_KEY") or os.getenv("WHATSAPP_API_KEY")
+    logger.info(f"[BRIDGE-HEADERS] API key loaded: {bool(api_key)}")
     if api_key:
         headers["X-API-Key"] = api_key
     return headers

--- a/whatsapp-mcp-server/tests/test_bridge.py
+++ b/whatsapp-mcp-server/tests/test_bridge.py
@@ -6,12 +6,35 @@ import pytest
 
 from lib.bridge import (
     BridgeError,
+    _get_headers,
     delete_message,
     edit_message,
     get_group_info,
     send_message,
     send_reaction,
 )
+
+
+class TestGetHeaders:
+    """Tests for API key header selection."""
+
+    def test_prefers_api_key(self, monkeypatch):
+        """API_KEY should take precedence when both names are set."""
+        monkeypatch.setenv("API_KEY", "primary-secret")
+        monkeypatch.setenv("WHATSAPP_API_KEY", "fallback-secret")
+
+        headers = _get_headers()
+
+        assert headers["X-API-Key"] == "primary-secret"
+
+    def test_falls_back_to_whatsapp_api_key(self, monkeypatch):
+        """WHATSAPP_API_KEY should be accepted when API_KEY is absent."""
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setenv("WHATSAPP_API_KEY", "fallback-secret")
+
+        headers = _get_headers()
+
+        assert headers["X-API-Key"] == "fallback-secret"
 
 
 class TestSendMessage:


### PR DESCRIPTION
## Summary
- accept `WHATSAPP_API_KEY` as a fallback when `API_KEY` is unset
- keep `API_KEY` as the preferred env var to preserve existing behavior
- document the MCP-side env var in the README and add coverage for both env names

## Testing
- `uv run python - <<'PY' ...` smoke check for `_get_headers()` precedence and fallback
- `uv run python -m pytest tests/test_bridge.py -q` could not run locally because `pytest` is not installed in the current `.venv`
