### PR TITLE
Fix document files showing as .bin in WhatsApp

### DIFF
--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -140,6 +140,17 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 			mediaType = whatsmeow.MediaVideo
 			mimeType = "video/quicktime"
 
+		// Document types
+		case "epub":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/epub+zip"
+		case "pdf":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/pdf"
+		case "cbz":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/x-cbz"
+
 		// Document types (for any other file type)
 		default:
 			mediaType = whatsmeow.MediaDocument
@@ -205,8 +216,10 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 				FileLength:    &resp.FileLength,
 			}
 		case whatsmeow.MediaDocument:
+			fileName := mediaPath[strings.LastIndex(mediaPath, "/")+1:]
 			msg.DocumentMessage = &waE2E.DocumentMessage{
-				Title:         proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
+				Title:         proto.String(fileName),
+				FileName:      proto.String(fileName),
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
 				URL:           &resp.URL,


### PR DESCRIPTION
When sending documents (epub, pdf, cbz, etc.) through the WhatsApp bridge, recipients see them as `.bin` files they can't open. There are two things going on here.

First, file extensions like `.epub`, `.pdf`, and `.cbz` don't have explicit cases in the media type switch, so they fall through to `application/octet-stream`. WhatsApp doesn't know what to do with that, so it shows `.bin`. This adds the correct mime type mappings for those formats.

Second, even with the right mime type, WhatsApp clients use the `FileName` field on `DocumentMessage` to determine what extension to show -- not just `Title`. Without `FileName` set, the original filename gets lost. This sets both fields, and extracts the filename into a local variable to keep things clean.