### PR TITLE
Fix reactions to other users' messages silently failing

### DIFF
--- a/whatsapp-bridge/internal/api/handlers.go
+++ b/whatsapp-bridge/internal/api/handlers.go
@@ -361,7 +361,7 @@ func (s *Server) handleReaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.client.SendReaction(req.ChatJID, req.MessageID, req.Emoji); err != nil {
+	if err := s.client.SendReaction(s.messageStore, req.ChatJID, req.MessageID, req.Emoji); err != nil {
 		SendJSONError(w, fmt.Sprintf("Failed to send reaction: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/whatsapp-bridge/internal/database/messages.go
+++ b/whatsapp-bridge/internal/database/messages.go
@@ -105,3 +105,14 @@ func (store *MessageStore) GetChats() (map[string]time.Time, error) {
 
 	return chats, nil
 }
+
+
+// GetMessageSender returns the sender JID and is_from_me flag for a message.
+// Used by SendReaction to build the correct message key.
+func (store *MessageStore) GetMessageSender(messageID, chatJID string) (sender string, isFromMe bool, err error) {
+	err = store.db.QueryRow(
+		"SELECT sender, is_from_me FROM messages WHERE id = ? AND chat_jid = ?",
+		messageID, chatJID,
+	).Scan(&sender, &isFromMe)
+	return
+}

--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -251,8 +251,10 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 	}
 }
 
-// SendReaction sends an emoji reaction to a message
-func (c *Client) SendReaction(chatJID, messageID, emoji string) error {
+// SendReaction sends an emoji reaction to a message.
+// It looks up the original message sender from the store so that
+// BuildReaction constructs the correct MessageKey (FromMe flag).
+func (c *Client) SendReaction(messageStore *database.MessageStore, chatJID, messageID, emoji string) error {
 	if !c.IsConnected() {
 		return fmt.Errorf("not connected to WhatsApp")
 	}
@@ -263,7 +265,18 @@ func (c *Client) SendReaction(chatJID, messageID, emoji string) error {
 	}
 
 	msgID := types.MessageID(messageID)
-	senderJID := c.Store.ID.ToNonAD()
+
+	// Look up the actual sender of the message being reacted to.
+	// BuildReaction needs the original message sender to set FromMe correctly.
+	senderJID := c.Store.ID.ToNonAD() // default: assume own message
+	if messageStore != nil {
+		senderStr, isFromMe, lookupErr := messageStore.GetMessageSender(messageID, chatJID)
+		if lookupErr == nil && !isFromMe {
+			if parsed, parseErr := types.ParseJID(senderStr); parseErr == nil {
+				senderJID = parsed.ToNonAD()
+			}
+		}
+	}
 
 	msg := c.Client.BuildReaction(chat, senderJID, msgID, emoji)
 	_, err = c.Client.SendMessage(context.Background(), chat, msg)


### PR DESCRIPTION
## Summary
- `SendReaction` always passes the bridge's own JID as the sender to `BuildReaction`, setting `FromMe=true` on the message key
- When reacting to messages from other people, WhatsApp silently drops the reaction because no matching "from me" message exists with that ID
- Fixes this by looking up the actual sender from the message store and using their JID when the message isn't from the bridge itself

## Test plan
- [ ] React to a message sent by another user, verify the reaction appears on their end
- [ ] React to a message sent by the bridge itself, verify it still works
- [ ] React to a message not in the store (edge case), verify it falls back to the old behavior