### PR TITLE
Add /api/download endpoint for media retrieval

### DIFF
--- a/docs/WEBHOOK.md
+++ b/docs/WEBHOOK.md
@@ -397,3 +397,34 @@ After the fix:
 2. Triggers are properly updated and persisted
 3. The webhook manager reloads the updated configuration
 4. New triggers are applied immediately to incoming messages
+
+### Media Download
+
+#### Download Media from Stored Message
+```bash
+POST /api/download
+Content-Type: application/json
+
+{
+  "message_id": "ABC123DEF456...",
+  "chat_jid": "1234567890@s.whatsapp.net"
+}
+```
+
+Downloads and decrypts media from a previously received message. The media encryption metadata is looked up from the message store, and whatsmeow handles the download and decryption.
+
+**Response:**
+```json
+{
+  "success": true,
+  "path": "/app/whatsapp-bridge/store/media/wa-media-ABC123DEF456.ogg",
+  "size": 7035
+}
+```
+
+The file is saved to the store media directory. The extension is determined by the media type (`.ogg` for audio, `.jpg` for images, `.mp4` for video, `.bin` for other).
+
+**Error responses:**
+- `404` - Message not found in store
+- `400` - Message has no downloadable media, or missing required fields
+- `500` - Failed to download or save the media

--- a/whatsapp-bridge/internal/api/handlers.go
+++ b/whatsapp-bridge/internal/api/handlers.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"whatsapp-bridge/internal/types"
+	"go.mau.fi/whatsmeow"
 )
 
 // handleSendMessage handles POST /api/send for sending WhatsApp messages.
@@ -1755,4 +1758,96 @@ func (s *Server) handleSyncStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+
+// handleDownloadMedia handles POST /api/download for downloading media from a stored message.
+func (s *Server) handleDownloadMedia(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		SendJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		MessageID string `json:"message_id"`
+		ChatJID   string `json:"chat_jid"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		SendJSONError(w, "Invalid request format", http.StatusBadRequest)
+		return
+	}
+
+	if req.MessageID == "" || req.ChatJID == "" {
+		SendJSONError(w, "message_id and chat_jid are required", http.StatusBadRequest)
+		return
+	}
+
+	var mediaURL string
+	var mediaKey, fileSHA256, fileEncSHA256 []byte
+	var fileLength uint64
+	var mediaType string
+
+	err := s.messageStore.GetDB().QueryRow(
+		"SELECT url, media_key, file_sha256, file_enc_sha256, file_length, media_type FROM messages WHERE id = ? AND chat_jid = ?",
+		req.MessageID, req.ChatJID,
+	).Scan(&mediaURL, &mediaKey, &fileSHA256, &fileEncSHA256, &fileLength, &mediaType)
+
+	if err != nil {
+		SendJSONError(w, fmt.Sprintf("Message not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	if mediaURL == "" || mediaKey == nil {
+		SendJSONError(w, "Message has no downloadable media", http.StatusBadRequest)
+		return
+	}
+
+	var wmMediaType whatsmeow.MediaType
+	switch mediaType {
+	case "image":
+		wmMediaType = whatsmeow.MediaImage
+	case "video":
+		wmMediaType = whatsmeow.MediaVideo
+	case "audio":
+		wmMediaType = whatsmeow.MediaAudio
+	case "document":
+		wmMediaType = whatsmeow.MediaDocument
+	default:
+		wmMediaType = whatsmeow.MediaDocument
+	}
+
+	directPath := mediaURL
+	if parsed, parseErr := url.Parse(mediaURL); parseErr == nil && parsed.Host != "" {
+		directPath = parsed.RequestURI()
+	}
+
+	data, err := s.client.DownloadMediaWithPath(r.Context(), directPath, fileEncSHA256, fileSHA256, mediaKey, int(fileLength), wmMediaType, "")
+	if err != nil {
+		SendJSONError(w, fmt.Sprintf("Failed to download media: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	ext := ".bin"
+	switch mediaType {
+	case "audio":
+		ext = ".ogg"
+	case "image":
+		ext = ".jpg"
+	case "video":
+		ext = ".mp4"
+	}
+
+	os.MkdirAll("/app/whatsapp-bridge/store/media", 0755)
+	tmpFile := fmt.Sprintf("/app/whatsapp-bridge/store/media/wa-media-%s%s", req.MessageID, ext)
+	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+		SendJSONError(w, fmt.Sprintf("Failed to save: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": true,
+		"path":    tmpFile,
+		"size":    len(data),
+	})
 }

--- a/whatsapp-bridge/internal/api/server.go
+++ b/whatsapp-bridge/internal/api/server.go
@@ -120,4 +120,7 @@ func (s *Server) registerHandlers() {
 
 	// Sync status monitoring
 	http.HandleFunc("/api/sync-status", SecureMiddleware(s.handleSyncStatus))
+
+	// Media download
+	http.HandleFunc("/api/download", SecureMiddleware(s.handleDownloadMedia))
 }

--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -21,6 +21,7 @@ import (
 var allowedMediaDirs = []string{
 	"/app/media",
 	"/app/store",
+	"/app/whatsapp-bridge/store",
 	"/tmp",
 }
 


### PR DESCRIPTION
## Summary
- Adds a `POST /api/download` endpoint that downloads and decrypts media from stored messages
- Given a `message_id` and `chat_jid`, looks up the encrypted media metadata, downloads and decrypts via whatsmeow, and saves to a local file
- Enables integrations that need to process incoming media (voice transcription, image analysis, etc.) without needing direct access to WhatsApp encryption keys
- Also adds `/app/whatsapp-bridge/store` to allowed media directories so downloaded files can be sent back through the bridge

## API
```
POST /api/download
{
  "message_id": "ABC123...",
  "chat_jid": "1234567890@s.whatsapp.net"
}

Response:
{
  "success": true,
  "path": "/app/whatsapp-bridge/store/media/wa-media-ABC123.ogg",
  "size": 7035
}
```

## Test plan
- [ ] Send a voice message to the bridge, call /api/download with the message ID, verify the decrypted audio file is saved
- [ ] Send an image, verify download works and returns correct extension
- [ ] Call with a non-existent message ID, verify 404 response
- [ ] Call with a text message (no media), verify appropriate error