### PR TITLE
fix: stabilize include_last_message=false query paths

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - 8.8.8.8
       - 8.8.4.4
     ports:
-      - "0.0.0.0:8180:8080"  # Localhost only for security
+      - "127.0.0.1:8180:8080"
     volumes:
       - ./store:/app/whatsapp-bridge/store
     environment:
@@ -80,7 +80,7 @@ services:
           memory: 300M
           cpus: '0.5'
     ports:
-      - "0.0.0.0:8090:8080"  # Unified Web UI (pairing + webhooks)
+      - "127.0.0.1:8090:8080"
     depends_on:
       - whatsapp-bridge
     restart: unless-stopped

--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -22,6 +22,63 @@ import (
 // mentionPattern matches @phone_number patterns in message text (7-15 digits)
 var mentionPattern = regexp.MustCompile(`@(\d{7,15})`)
 
+func mediaTypeAndMimeType(mediaPath string) (whatsmeow.MediaType, string) {
+	fileExt := strings.TrimPrefix(strings.ToLower(filepath.Ext(mediaPath)), ".")
+
+	switch fileExt {
+	case "jpg", "jpeg":
+		return whatsmeow.MediaImage, "image/jpeg"
+	case "png":
+		return whatsmeow.MediaImage, "image/png"
+	case "gif":
+		return whatsmeow.MediaImage, "image/gif"
+	case "webp":
+		return whatsmeow.MediaImage, "image/webp"
+	case "ogg":
+		return whatsmeow.MediaAudio, "audio/ogg; codecs=opus"
+	case "mp3":
+		return whatsmeow.MediaAudio, "audio/mpeg"
+	case "m4a", "aac":
+		return whatsmeow.MediaAudio, "audio/mp4"
+	case "mp4":
+		return whatsmeow.MediaVideo, "video/mp4"
+	case "avi":
+		return whatsmeow.MediaVideo, "video/avi"
+	case "mov":
+		return whatsmeow.MediaVideo, "video/quicktime"
+	case "epub":
+		return whatsmeow.MediaDocument, "application/epub+zip"
+	case "pdf":
+		return whatsmeow.MediaDocument, "application/pdf"
+	case "cbz":
+		return whatsmeow.MediaDocument, "application/x-cbz"
+	case "doc":
+		return whatsmeow.MediaDocument, "application/msword"
+	case "docx":
+		return whatsmeow.MediaDocument, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case "xls":
+		return whatsmeow.MediaDocument, "application/vnd.ms-excel"
+	case "xlsx":
+		return whatsmeow.MediaDocument, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case "ppt":
+		return whatsmeow.MediaDocument, "application/vnd.ms-powerpoint"
+	case "pptx":
+		return whatsmeow.MediaDocument, "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case "txt":
+		return whatsmeow.MediaDocument, "text/plain"
+	case "csv":
+		return whatsmeow.MediaDocument, "text/csv"
+	case "zip":
+		return whatsmeow.MediaDocument, "application/zip"
+	default:
+		return whatsmeow.MediaDocument, "application/octet-stream"
+	}
+}
+
+func documentFileName(mediaPath string) string {
+	return filepath.Base(mediaPath)
+}
+
 // extractMentionsFromText detects @number mentions in text and returns WhatsApp JIDs
 func extractMentionsFromText(text string) []string {
 	matches := mentionPattern.FindAllStringSubmatch(text, -1)
@@ -127,90 +184,7 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 			return bridgeTypes.SendResult{Success: false, Error: fmt.Sprintf("Error reading media file: %v", err)}
 		}
 
-		// Determine media type and mime type based on file extension
-		fileExt := strings.ToLower(mediaPath[strings.LastIndex(mediaPath, ".")+1:])
-		var mediaType whatsmeow.MediaType
-		var mimeType string
-
-		// Handle different media types
-		switch fileExt {
-		// Image types
-		case "jpg", "jpeg":
-			mediaType = whatsmeow.MediaImage
-			mimeType = "image/jpeg"
-		case "png":
-			mediaType = whatsmeow.MediaImage
-			mimeType = "image/png"
-		case "gif":
-			mediaType = whatsmeow.MediaImage
-			mimeType = "image/gif"
-		case "webp":
-			mediaType = whatsmeow.MediaImage
-			mimeType = "image/webp"
-
-		// Audio types
-		case "ogg":
-			mediaType = whatsmeow.MediaAudio
-			mimeType = "audio/ogg; codecs=opus"
-		case "mp3":
-			mediaType = whatsmeow.MediaAudio
-			mimeType = "audio/mpeg"
-		case "m4a", "aac":
-			mediaType = whatsmeow.MediaAudio
-			mimeType = "audio/mp4"
-
-		// Video types
-		case "mp4":
-			mediaType = whatsmeow.MediaVideo
-			mimeType = "video/mp4"
-		case "avi":
-			mediaType = whatsmeow.MediaVideo
-			mimeType = "video/avi"
-		case "mov":
-			mediaType = whatsmeow.MediaVideo
-			mimeType = "video/quicktime"
-
-		// Document types
-		case "epub":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/epub+zip"
-		case "pdf":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/pdf"
-		case "cbz":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/x-cbz"
-		case "doc":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/msword"
-		case "docx":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-		case "xls":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/vnd.ms-excel"
-		case "xlsx":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-		case "ppt":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/vnd.ms-powerpoint"
-		case "pptx":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-		case "txt":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "text/plain"
-		case "csv":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "text/csv"
-		case "zip":
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/zip"
-		default:
-			mediaType = whatsmeow.MediaDocument
-			mimeType = "application/octet-stream"
-		}
+		mediaType, mimeType := mediaTypeAndMimeType(mediaPath)
 
 		// Upload media to WhatsApp servers
 		resp, err := c.Upload(context.Background(), mediaData, mediaType)
@@ -271,7 +245,7 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 				FileLength:    &resp.FileLength,
 			}
 		case whatsmeow.MediaDocument:
-			docName := filepath.Base(mediaPath)
+			docName := documentFileName(mediaPath)
 			msg.DocumentMessage = &waE2E.DocumentMessage{
 				Title:         proto.String(docName),
 				FileName:      proto.String(docName),

--- a/whatsapp-bridge/internal/whatsapp/messages_test.go
+++ b/whatsapp-bridge/internal/whatsapp/messages_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"go.mau.fi/whatsmeow"
 )
 
 func TestValidateMediaPath(t *testing.T) {
@@ -13,24 +15,18 @@ func TestValidateMediaPath(t *testing.T) {
 		wantErr     bool
 		errContains string
 	}{
-		// Valid paths
 		{"empty path", "", false, ""},
 		{"allowed /app/media", "/app/media/file.jpg", false, ""},
 		{"allowed /app/store", "/app/store/data.db", false, ""},
 		{"allowed /tmp", "/tmp/upload.png", false, ""},
-
-		// Path traversal attempts (should fail)
 		{"path traversal ../", "/app/media/../etc/passwd", true, "traversal"},
 		{"path traversal multiple", "/app/media/../../etc/passwd", true, "traversal"},
 		{"path traversal in middle", "/app/../../../etc/passwd", true, "traversal"},
-
-		// Outside allowed directories (should fail when DISABLE_PATH_CHECK is not set)
 		{"outside allowed /etc", "/etc/passwd", true, "outside allowed"},
 		{"outside allowed /home", "/home/user/file.txt", true, "outside allowed"},
 		{"outside allowed /var", "/var/log/syslog", true, "outside allowed"},
 	}
 
-	// Ensure DISABLE_PATH_CHECK is not set for these tests
 	os.Unsetenv("DISABLE_PATH_CHECK")
 
 	for _, tt := range tests {
@@ -45,41 +41,126 @@ func TestValidateMediaPath(t *testing.T) {
 				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.errContains)) {
 					t.Errorf("validateMediaPath(%s) error = %v, want error containing %q", tt.path, err, tt.errContains)
 				}
-			} else {
-				if err != nil {
-					t.Errorf("validateMediaPath(%s) = %v, want nil", tt.path, err)
-				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("validateMediaPath(%s) = %v, want nil", tt.path, err)
 			}
 		})
 	}
 }
 
 func TestValidateMediaPath_DisableCheck(t *testing.T) {
-	// Save and restore env var
 	original := os.Getenv("DISABLE_PATH_CHECK")
 	defer os.Setenv("DISABLE_PATH_CHECK", original)
 
-	// Enable path check bypass
 	os.Setenv("DISABLE_PATH_CHECK", "true")
 
-	// Should now allow paths outside allowed directories
-	// Note: Path traversal attempts still blocked
-	err := validateMediaPath("/home/user/file.txt")
-	if err != nil {
+	if err := validateMediaPath("/home/user/file.txt"); err != nil {
 		t.Errorf("With DISABLE_PATH_CHECK=true, validateMediaPath should allow external paths, got: %v", err)
 	}
 }
 
 func TestValidateMediaPath_TraversalAlwaysBlocked(t *testing.T) {
-	// Save and restore env var
 	original := os.Getenv("DISABLE_PATH_CHECK")
 	defer os.Setenv("DISABLE_PATH_CHECK", original)
 
-	// Even with DISABLE_PATH_CHECK=true, path traversal should be blocked
 	os.Setenv("DISABLE_PATH_CHECK", "true")
 
-	err := validateMediaPath("/app/media/../../../etc/passwd")
-	if err == nil {
+	if err := validateMediaPath("/app/media/../../../etc/passwd"); err == nil {
 		t.Error("Path traversal should be blocked even with DISABLE_PATH_CHECK=true")
+	}
+}
+
+func TestMediaTypeAndMimeType(t *testing.T) {
+	tests := []struct {
+		name          string
+		mediaPath     string
+		wantMediaType whatsmeow.MediaType
+		wantMimeType  string
+	}{
+		{
+			name:          "pdf document",
+			mediaPath:     "/tmp/report.pdf",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/pdf",
+		},
+		{
+			name:          "docx document",
+			mediaPath:     "/tmp/spec.DOCX",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		},
+		{
+			name:          "xlsx document",
+			mediaPath:     "/tmp/budget.xlsx",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		},
+		{
+			name:          "cbz document",
+			mediaPath:     "/tmp/comic.cbz",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/x-cbz",
+		},
+		{
+			name:          "jpg image",
+			mediaPath:     "/tmp/photo.jpg",
+			wantMediaType: whatsmeow.MediaImage,
+			wantMimeType:  "image/jpeg",
+		},
+		{
+			name:          "unknown extension fallback",
+			mediaPath:     "/tmp/archive.weird",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/octet-stream",
+		},
+		{
+			name:          "no extension fallback",
+			mediaPath:     "/tmp/readme",
+			wantMediaType: whatsmeow.MediaDocument,
+			wantMimeType:  "application/octet-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMediaType, gotMimeType := mediaTypeAndMimeType(tt.mediaPath)
+			if gotMediaType != tt.wantMediaType {
+				t.Fatalf("mediaTypeAndMimeType() mediaType = %v, want %v", gotMediaType, tt.wantMediaType)
+			}
+			if gotMimeType != tt.wantMimeType {
+				t.Fatalf("mediaTypeAndMimeType() mimeType = %q, want %q", gotMimeType, tt.wantMimeType)
+			}
+		})
+	}
+}
+
+func TestDocumentFileName(t *testing.T) {
+	tests := []struct {
+		name      string
+		mediaPath string
+		want      string
+	}{
+		{
+			name:      "unix path",
+			mediaPath: "/tmp/Presidio-statement-May-2026.pdf",
+			want:      "Presidio-statement-May-2026.pdf",
+		},
+		{
+			name:      "windows path",
+			mediaPath: `C:\tmp\Quarterly Report.xlsx`,
+			want:      "Quarterly Report.xlsx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := documentFileName(tt.mediaPath)
+			if got != tt.want {
+				t.Fatalf("documentFileName() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/whatsapp-mcp-server/lib/database.py
+++ b/whatsapp-mcp-server/lib/database.py
@@ -593,19 +593,16 @@ def list_chats(
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
 
-        if include_last_message:
-            query_sql = """
-                SELECT c.jid, c.name,
-                       m.timestamp, m.content, m.id, m.sender, m.is_from_me, m.sender_name
-                FROM chats c
-                LEFT JOIN (
-                    SELECT chat_jid, timestamp, content, id, sender, is_from_me, sender_name,
-                           ROW_NUMBER() OVER (PARTITION BY chat_jid ORDER BY timestamp DESC) as rn
-                    FROM messages
-                ) m ON c.jid = m.chat_jid AND m.rn = 1
-            """
-        else:
-            query_sql = "SELECT jid, name, NULL, NULL, NULL, NULL, NULL, NULL FROM chats"
+        query_sql = """
+            SELECT c.jid, c.name,
+                   m.timestamp, m.content, m.id, m.sender, m.is_from_me, m.sender_name
+            FROM chats c
+            LEFT JOIN (
+                SELECT chat_jid, timestamp, content, id, sender, is_from_me, sender_name,
+                       ROW_NUMBER() OVER (PARTITION BY chat_jid ORDER BY timestamp DESC, id DESC) as rn
+                FROM messages
+            ) m ON c.jid = m.chat_jid AND m.rn = 1
+        """
 
         where_clauses = []
         params: list[Any] = []
@@ -631,9 +628,14 @@ def list_chats(
 
         result = []
         for chat in chats:
+            last_message = chat[3] if include_last_message else None
+            last_message_id = chat[4] if include_last_message else None
+            last_sender = chat[5] if include_last_message else None
+            last_is_from_me = bool(chat[6]) if include_last_message and chat[6] is not None else None
+
             # Use stored sender_name if available, otherwise fallback to lookup
             last_sender_name = None
-            if chat[5]:  # if there's a last_sender
+            if include_last_message and chat[5]:  # if there's a last_sender
                 last_sender_name = chat[7] if chat[7] else get_sender_name(chat[5])
 
             # Get chat statistics
@@ -681,11 +683,11 @@ def list_chats(
                 jid=chat[0],
                 name=chat[1],
                 last_message_time=last_msg_time,
-                last_message=chat[3],
-                last_message_id=chat[4],
-                last_sender=chat[5],
+                last_message=last_message,
+                last_message_id=last_message_id,
+                last_sender=last_sender,
                 last_sender_name=last_sender_name,
-                last_is_from_me=bool(chat[6]) if chat[6] is not None else None,
+                last_is_from_me=last_is_from_me,
                 total_message_count=total_msgs,
                 message_count_today=msgs_today,
                 message_count_last_7_days=msgs_week,

--- a/whatsapp-mcp-server/tests/test_database.py
+++ b/whatsapp-mcp-server/tests/test_database.py
@@ -190,6 +190,29 @@ class TestListChats:
             else:
                 assert chat["chat_type"] == "individual"
 
+    def test_list_chats_include_last_message_false_no_sql_error(self, temp_messages_db, monkeypatch):
+        """Regression: include_last_message=False should not break query aliases."""
+        monkeypatch.setenv("MESSAGES_DB_PATH", temp_messages_db)
+        monkeypatch.setattr("lib.database.MESSAGES_DB_PATH", temp_messages_db)
+
+        chats = list_chats(limit=10, include_last_message=False)
+
+        assert len(chats) > 0
+        for chat in chats:
+            assert "last_message" not in chat
+            assert "last_message_id" not in chat
+            assert "last_sender" not in chat
+            assert "last_is_from_me" not in chat
+
+    def test_list_chats_include_last_message_false_with_query(self, temp_messages_db, monkeypatch):
+        """Regression: include_last_message=False with query should not reference missing aliases."""
+        monkeypatch.setenv("MESSAGES_DB_PATH", temp_messages_db)
+        monkeypatch.setattr("lib.database.MESSAGES_DB_PATH", temp_messages_db)
+
+        chats = list_chats(query="Test", limit=10, include_last_message=False)
+
+        assert len(chats) > 0
+
 
 class TestGetChatStatistics:
     """Tests for get_chat_statistics function."""

--- a/whatsapp-mcp-server/tests/test_whatsapp_list_chats.py
+++ b/whatsapp-mcp-server/tests/test_whatsapp_list_chats.py
@@ -5,7 +5,7 @@ import sqlite3
 import tempfile
 from datetime import datetime, timedelta
 
-from whatsapp import list_chats
+from whatsapp import get_chat, list_chats
 
 
 def _build_messages_db() -> str:
@@ -87,5 +87,22 @@ def test_list_chats_include_last_message_true_returns_latest(monkeypatch):
         assert chats[0]["last_message_id"] == "m2"
         assert chats[0]["last_sender"] == "111@s.whatsapp.net"
         assert chats[0]["last_is_from_me"] == 0
+    finally:
+        os.unlink(db_path)
+
+
+def test_get_chat_include_last_message_false_no_sql_error(monkeypatch):
+    db_path = _build_messages_db()
+    try:
+        monkeypatch.setenv("MESSAGES_DB_PATH", db_path)
+        monkeypatch.setattr("whatsapp.MESSAGES_DB_PATH", db_path)
+
+        chat = get_chat("111@s.whatsapp.net", include_last_message=False)
+
+        assert chat is not None
+        assert chat["jid"] == "111@s.whatsapp.net"
+        assert chat["last_message"] is None
+        assert chat["last_sender"] is None
+        assert chat["last_is_from_me"] is None
     finally:
         os.unlink(db_path)

--- a/whatsapp-mcp-server/tests/test_whatsapp_list_chats.py
+++ b/whatsapp-mcp-server/tests/test_whatsapp_list_chats.py
@@ -1,0 +1,91 @@
+"""Regression tests for whatsapp.py list_chats."""
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+
+from whatsapp import list_chats
+
+
+def _build_messages_db() -> str:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE chats (
+            jid TEXT PRIMARY KEY,
+            name TEXT,
+            last_message_time TEXT
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            chat_jid TEXT,
+            sender TEXT,
+            content TEXT,
+            timestamp TEXT,
+            is_from_me INTEGER
+        )
+    """)
+
+    t0 = datetime.now()
+    t1 = (t0 + timedelta(seconds=1)).isoformat()
+    t0s = t0.isoformat()
+
+    cursor.execute(
+        "INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)",
+        ("111@s.whatsapp.net", "Alice", t1),
+    )
+    cursor.execute(
+        "INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me) VALUES (?, ?, ?, ?, ?, ?)",
+        ("m1", "111@s.whatsapp.net", "111@s.whatsapp.net", "old", t0s, 0),
+    )
+    cursor.execute(
+        "INSERT INTO messages (id, chat_jid, sender, content, timestamp, is_from_me) VALUES (?, ?, ?, ?, ?, ?)",
+        ("m2", "111@s.whatsapp.net", "111@s.whatsapp.net", "new", t1, 0),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_list_chats_include_last_message_false_no_sql_error(monkeypatch):
+    db_path = _build_messages_db()
+    try:
+        monkeypatch.setenv("MESSAGES_DB_PATH", db_path)
+        monkeypatch.setattr("whatsapp.MESSAGES_DB_PATH", db_path)
+
+        chats = list_chats(limit=10, include_last_message=False)
+
+        assert len(chats) == 1
+        assert chats[0]["jid"] == "111@s.whatsapp.net"
+        assert chats[0]["last_message"] is None
+        assert chats[0]["last_message_id"] is None
+        assert chats[0]["last_sender"] is None
+        assert chats[0]["last_is_from_me"] is None
+    finally:
+        os.unlink(db_path)
+
+
+def test_list_chats_include_last_message_true_returns_latest(monkeypatch):
+    db_path = _build_messages_db()
+    try:
+        monkeypatch.setenv("MESSAGES_DB_PATH", db_path)
+        monkeypatch.setattr("whatsapp.MESSAGES_DB_PATH", db_path)
+
+        chats = list_chats(limit=10, include_last_message=True)
+
+        assert len(chats) == 1
+        assert chats[0]["jid"] == "111@s.whatsapp.net"
+        assert chats[0]["last_message"] == "new"
+        assert chats[0]["last_message_id"] == "m2"
+        assert chats[0]["last_sender"] == "111@s.whatsapp.net"
+        assert chats[0]["last_is_from_me"] == 0
+    finally:
+        os.unlink(db_path)

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -777,17 +777,23 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
                 c.jid,
                 c.name,
                 c.last_message_time,
-                m.content as last_message,
-                m.sender as last_sender,
-                m.is_from_me as last_is_from_me
+                lm.content as last_message,
+                lm.sender as last_sender,
+                lm.is_from_me as last_is_from_me
             FROM chats c
+            LEFT JOIN (
+                SELECT
+                    chat_jid,
+                    content,
+                    sender,
+                    is_from_me,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY chat_jid
+                        ORDER BY timestamp DESC, id DESC
+                    ) as rn
+                FROM messages
+            ) lm ON c.jid = lm.chat_jid AND lm.rn = 1
         """
-
-        if include_last_message:
-            query += """
-                LEFT JOIN messages m ON c.jid = m.chat_jid
-                AND c.last_message_time = m.timestamp
-            """
 
         query += " WHERE c.jid = ?"
 
@@ -797,13 +803,17 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
         if not chat_data:
             return None
 
+        last_message = chat_data[3] if include_last_message else None
+        last_sender = chat_data[4] if include_last_message else None
+        last_is_from_me = chat_data[5] if include_last_message else None
+
         chat = Chat(
             jid=chat_data[0],
             name=chat_data[1],
             last_message_time=datetime.fromisoformat(chat_data[2]) if chat_data[2] else None,
-            last_message=chat_data[3],
-            last_sender=chat_data[4],
-            last_is_from_me=chat_data[5],
+            last_message=last_message,
+            last_sender=last_sender,
+            last_is_from_me=last_is_from_me,
         )
         return chat.to_dict()
 

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -504,26 +504,35 @@ def list_chats(
         except Exception as e:
             print(f"Debug: Error counting chats: {e}")
 
-        # Build base query
+        # Build base query.
+        # Always join the latest message per chat to avoid SELECT/JOIN drift when
+        # include_last_message=False (regression in issue #39).
         query_parts = [
             """
             SELECT
                 chats.jid,
                 chats.name,
                 chats.last_message_time,
-                messages.content as last_message,
-                messages.id as last_message_id,
-                messages.sender as last_sender,
-                messages.is_from_me as last_is_from_me
+                lm.content as last_message,
+                lm.id as last_message_id,
+                lm.sender as last_sender,
+                lm.is_from_me as last_is_from_me
             FROM chats
-        """
+            LEFT JOIN (
+                SELECT
+                    chat_jid,
+                    content,
+                    id,
+                    sender,
+                    is_from_me,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY chat_jid
+                        ORDER BY timestamp DESC, id DESC
+                    ) as rn
+                FROM messages
+            ) lm ON chats.jid = lm.chat_jid AND lm.rn = 1
+            """
         ]
-
-        if include_last_message:
-            query_parts.append("""
-                LEFT JOIN messages ON chats.jid = messages.chat_jid 
-                AND chats.last_message_time = messages.timestamp
-            """)
 
         where_clauses = []
         params = []
@@ -549,14 +558,19 @@ def list_chats(
 
         result = []
         for chat_data in chats:
+            last_message = chat_data[3] if include_last_message else None
+            last_message_id = chat_data[4] if include_last_message else None
+            last_sender = chat_data[5] if include_last_message else None
+            last_is_from_me = chat_data[6] if include_last_message else None
+
             chat = Chat(
                 jid=chat_data[0],
                 name=chat_data[1],
                 last_message_time=datetime.fromisoformat(chat_data[2]) if chat_data[2] else None,
-                last_message=chat_data[3],
-                last_message_id=chat_data[4],
-                last_sender=chat_data[5],
-                last_is_from_me=chat_data[6],
+                last_message=last_message,
+                last_message_id=last_message_id,
+                last_sender=last_sender,
+                last_is_from_me=last_is_from_me,
             )
             result.append(chat.to_dict())
 


### PR DESCRIPTION
## Summary
- fix `whatsapp.py:list_chats` false branch SQL regression
- fix `whatsapp.py:get_chat` false branch SQL regression
- fix `lib/database.py:list_chats` alias/ORDER/WHERE break when `include_last_message=False`
- add regression tests for list/get chat false-path behavior
- include existing compose localhost bind change

## Validation
- `pytest -q tests/test_whatsapp_list_chats.py tests/test_database.py -k "list_chats or get_chat"`
- local repro for `include_last_message=False` now returns rows (no SQL error)