### PR TITLE
Fix core message persistence

### DIFF
--- a/whatsapp-bridge/internal/database/messages.go
+++ b/whatsapp-bridge/internal/database/messages.go
@@ -12,7 +12,16 @@ import (
 // StoreChat stores a chat in the database
 func (store *MessageStore) StoreChat(jid, name string, lastMessageTime time.Time) error {
 	_, err := store.db.Exec(
-		"INSERT OR REPLACE INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)",
+		`INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
+		ON CONFLICT(jid) DO UPDATE SET
+			name = CASE
+				WHEN excluded.name != '' THEN excluded.name
+				ELSE chats.name
+			END,
+			last_message_time = CASE
+				WHEN chats.last_message_time IS NULL OR excluded.last_message_time > chats.last_message_time THEN excluded.last_message_time
+				ELSE chats.last_message_time
+			END`,
 		jid, name, lastMessageTime,
 	)
 	return err

--- a/whatsapp-bridge/internal/database/messages_test.go
+++ b/whatsapp-bridge/internal/database/messages_test.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestMessageStore(t *testing.T) *MessageStore {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared&_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := createTables(db); err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	return &MessageStore{db: db}
+}
+
+func TestStoreChatKeepsNewestTimestamp(t *testing.T) {
+	store := newTestMessageStore(t)
+	older := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(2 * time.Hour)
+
+	if err := store.StoreChat("123@s.whatsapp.net", "Alice", newer); err != nil {
+		t.Fatalf("store newer chat: %v", err)
+	}
+	if err := store.StoreChat("123@s.whatsapp.net", "Alice Old", older); err != nil {
+		t.Fatalf("store older chat: %v", err)
+	}
+
+	var name string
+	var got time.Time
+	if err := store.db.QueryRow("SELECT name, last_message_time FROM chats WHERE jid = ?", "123@s.whatsapp.net").Scan(&name, &got); err != nil {
+		t.Fatalf("read chat: %v", err)
+	}
+	if !got.Equal(newer) {
+		t.Fatalf("last_message_time = %v, want %v", got, newer)
+	}
+	if name != "Alice Old" {
+		t.Fatalf("name = %q, want latest non-empty name", name)
+	}
+}
+
+func TestStoreChatEmptyNameDoesNotEraseExistingName(t *testing.T) {
+	store := newTestMessageStore(t)
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+
+	if err := store.StoreChat("123@s.whatsapp.net", "Alice", now); err != nil {
+		t.Fatalf("store named chat: %v", err)
+	}
+	if err := store.StoreChat("123@s.whatsapp.net", "", now.Add(time.Hour)); err != nil {
+		t.Fatalf("store empty-name chat: %v", err)
+	}
+
+	var name string
+	if err := store.db.QueryRow("SELECT name FROM chats WHERE jid = ?", "123@s.whatsapp.net").Scan(&name); err != nil {
+		t.Fatalf("read chat: %v", err)
+	}
+	if name != "Alice" {
+		t.Fatalf("name = %q, want existing name", name)
+	}
+}

--- a/whatsapp-bridge/internal/whatsapp/handlers.go
+++ b/whatsapp-bridge/internal/whatsapp/handlers.go
@@ -13,6 +13,8 @@ import (
 	"whatsapp-bridge/internal/database"
 
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -208,22 +210,12 @@ func (c *Client) HandleHistorySync(messageStore *database.MessageStore, historyS
 		// Get appropriate chat name by passing the history sync conversation directly
 		name := c.GetChatName(messageStore, jid, chatJID, conversation, "")
 
-		// Process messages
 		messages := conversation.Messages
 		if len(messages) > 0 {
-			// Update chat with latest message timestamp
-			latestMsg := messages[0]
-			if latestMsg == nil || latestMsg.Message == nil {
+			timestamp, ok := latestHistoryMessageTime(messages)
+			if !ok {
 				continue
 			}
-
-			// Get timestamp from message info
-			ts := latestMsg.Message.GetMessageTimestamp()
-			if ts == 0 {
-				continue
-			}
-			timestamp := time.Unix(int64(ts), 0)
-
 			if err := messageStore.StoreChat(chatJID, name, timestamp); err != nil {
 				c.logger.Warnf("Failed to store chat: %v", err)
 			}
@@ -257,23 +249,7 @@ func (c *Client) HandleHistorySync(messageStore *database.MessageStore, historyS
 					continue
 				}
 
-				// Determine sender
-				var sender string
-				isFromMe := false
-				if msg.Message.Key != nil {
-					if msg.Message.Key.FromMe != nil {
-						isFromMe = *msg.Message.Key.FromMe
-					}
-					if !isFromMe && msg.Message.Key.Participant != nil && *msg.Message.Key.Participant != "" {
-						sender = *msg.Message.Key.Participant
-					} else if isFromMe {
-						sender = c.Store.ID.User
-					} else {
-						sender = jid.User
-					}
-				} else {
-					sender = jid.User
-				}
+				sender, isFromMe := c.historyMessageSender(jid, msg.Message.Key)
 
 				// Store message
 				msgID := ""
@@ -326,6 +302,38 @@ func (c *Client) HandleHistorySync(messageStore *database.MessageStore, historyS
 	}
 
 	c.logger.Infof("History sync complete. Stored %d messages.", syncedCount)
+}
+
+func latestHistoryMessageTime(messages []*waHistorySync.HistorySyncMsg) (time.Time, bool) {
+	var latest time.Time
+	for _, msg := range messages {
+		if msg == nil || msg.Message == nil {
+			continue
+		}
+		ts := msg.Message.GetMessageTimestamp()
+		if ts == 0 {
+			continue
+		}
+		timestamp := time.Unix(int64(ts), 0)
+		if latest.IsZero() || timestamp.After(latest) {
+			latest = timestamp
+		}
+	}
+	return latest, !latest.IsZero()
+}
+
+func (c *Client) historyMessageSender(chat types.JID, key *waCommon.MessageKey) (string, bool) {
+	isFromMe := false
+	if key != nil && key.FromMe != nil {
+		isFromMe = *key.FromMe
+	}
+	if !isFromMe && key != nil && key.Participant != nil && *key.Participant != "" {
+		return *key.Participant, false
+	}
+	if isFromMe && c.Store != nil && c.Store.ID != nil {
+		return c.Store.ID.ToNonAD().String(), true
+	}
+	return chat.ToNonAD().String(), isFromMe
 }
 
 // autoDownloadMedia downloads and saves media to disk immediately after receiving a message,

--- a/whatsapp-bridge/internal/whatsapp/history_test.go
+++ b/whatsapp-bridge/internal/whatsapp/history_test.go
@@ -1,0 +1,81 @@
+package whatsapp
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	waWeb "go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestLatestHistoryMessageTimeUsesMaxTimestamp(t *testing.T) {
+	older := uint64(1_768_000_000)
+	newer := older + 3600
+
+	got, ok := latestHistoryMessageTime([]*waHistorySync.HistorySyncMsg{
+		historyMsg("old", older, false),
+		nil,
+		historyMsg("new", newer, false),
+	})
+	if !ok {
+		t.Fatal("latestHistoryMessageTime() ok = false, want true")
+	}
+
+	want := time.Unix(int64(newer), 0)
+	if !got.Equal(want) {
+		t.Fatalf("latestHistoryMessageTime() = %v, want %v", got, want)
+	}
+}
+
+func TestHistoryMessageSenderUsesFullOwnJID(t *testing.T) {
+	own := types.JID{User: "111", Server: "s.whatsapp.net"}
+	client := &Client{
+		Client: &whatsmeow.Client{Store: &store.Device{ID: &own}},
+	}
+	chat := types.JID{User: "222", Server: "s.whatsapp.net"}
+
+	sender, fromMe := client.historyMessageSender(chat, &waCommon.MessageKey{FromMe: proto.Bool(true)})
+	if !fromMe {
+		t.Fatal("fromMe = false, want true")
+	}
+	if sender != "111@s.whatsapp.net" {
+		t.Fatalf("sender = %q, want full own JID", sender)
+	}
+}
+
+func TestHistoryMessageSenderPrefersParticipant(t *testing.T) {
+	client := &Client{}
+	chat := types.JID{User: "12345", Server: "g.us"}
+
+	sender, fromMe := client.historyMessageSender(chat, &waCommon.MessageKey{
+		FromMe:      proto.Bool(false),
+		Participant: proto.String("333@s.whatsapp.net"),
+	})
+	if fromMe {
+		t.Fatal("fromMe = true, want false")
+	}
+	if sender != "333@s.whatsapp.net" {
+		t.Fatalf("sender = %q, want participant JID", sender)
+	}
+}
+
+func historyMsg(id string, timestamp uint64, fromMe bool) *waHistorySync.HistorySyncMsg {
+	return &waHistorySync.HistorySyncMsg{
+		Message: &waWeb.WebMessageInfo{
+			Key: &waCommon.MessageKey{
+				ID:     proto.String(id),
+				FromMe: proto.Bool(fromMe),
+			},
+			MessageTimestamp: proto.Uint64(timestamp),
+			Message: &waE2E.Message{
+				Conversation: proto.String(id),
+			},
+		},
+	}
+}

--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -76,7 +76,7 @@ func mediaTypeAndMimeType(mediaPath string) (whatsmeow.MediaType, string) {
 }
 
 func documentFileName(mediaPath string) string {
-	return filepath.Base(mediaPath)
+	return filepath.Base(strings.ReplaceAll(mediaPath, "\\", "/"))
 }
 
 // extractMentionsFromText detects @number mentions in text and returns WhatsApp JIDs

--- a/whatsapp-bridge/internal/whatsapp/messages.go
+++ b/whatsapp-bridge/internal/whatsapp/messages.go
@@ -298,22 +298,29 @@ func (c *Client) SendMessage(messageStore *database.MessageStore, recipient stri
 	_ = c.SendTypingIndicator(recipientJID.String(), "paused")
 	c.antiban.AfterSend(antiban.Text)
 
+	content := ExtractTextContent(msg)
+	mediaType, filename, url, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength := ExtractMediaInfo(msg)
+	sender := ""
+	if c.Store != nil && c.Store.ID != nil {
+		sender = c.Store.ID.ToNonAD().String()
+	}
+
 	_ = messageStore.StoreMessage(
 		sendResp.ID, // Use the ID from SendResponse
 		recipientJID.String(),
-		c.Store.ID.User,       // Use the client's user ID as sender
-		c.Store.ID.User,       // SenderName - use our own user ID for sent messages
-		msg.GetConversation(), // Use the conversation text
-		sendResp.Timestamp,    // Use the Timestamp from SendResponse
-		true,                  // IsFromMe is true since we are sending this message
-		"",
-		"",
-		"",
-		"",  // directPath
-		nil, // Replace "" with nil for []byte arguments
-		nil, // Replace "" with nil for []byte arguments
-		nil, // Replace "" with nil for []byte arguments
-		0,
+		sender,
+		sender,
+		content,
+		sendResp.Timestamp, // Use the Timestamp from SendResponse
+		true,               // IsFromMe is true since we are sending this message
+		mediaType,
+		filename,
+		url,
+		directPath,
+		mediaKey,
+		fileSHA256,
+		fileEncSHA256,
+		fileLength,
 	)
 
 	return bridgeTypes.SendResult{


### PR DESCRIPTION
Fix P0 correctness bugs.\n\n- store sent captions, rich text, media metadata\n- keep full own JID for sent/history messages\n- use max history timestamp, not first message\n- avoid chat row replace/stale timestamp overwrite\n- add Go tests\n\nTests:\n- go test ./...\n- python -m pytest -q