### PR TITLE
Curate MCP tool surface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,12 @@ uv run python main.py
 uv run python check.py
 ```
 
-### Webhook UI (whatsapp-webhook-ui/)
+### Web UI (whatsapp-web-ui/)
 
 ```bash
-cd whatsapp-webhook-ui
-python3 -m http.server 8089
+cd whatsapp-web-ui
+npm install
+npm run dev
 ```
 
 ## Code Style
@@ -83,7 +84,7 @@ python3 -m http.server 8089
 ```
 whatsapp-bridge/     # Go - WhatsApp connection, REST API
 whatsapp-mcp-server/ # Python - MCP tools, Claude integration
-whatsapp-webhook-ui/ # HTML/JS - Webhook management UI
+whatsapp-web-ui/     # HTML/JS - Chat/contact/webhook UI
 ```
 
 ## Adding New MCP Tools
@@ -91,8 +92,10 @@ whatsapp-webhook-ui/ # HTML/JS - Webhook management UI
 1. Add Go endpoint in `whatsapp-bridge/internal/api/handlers.go`
 2. Add route in `whatsapp-bridge/internal/api/server.go`
 3. Add Python function in `whatsapp-mcp-server/whatsapp.py`
-4. Add MCP tool in `whatsapp-mcp-server/main.py` and `gradio-main.py`
-5. Update README tool list
+4. Prefer extending an existing composable MCP tool in `whatsapp-mcp-server/main.py`
+5. Add a new MCP tool only for a distinct user task, not a one-endpoint wrapper
+6. Add/update `whatsapp-mcp-server/tests/test_main_tools.py`
+7. Update README tool list
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WhatsApp MCP Extended
 
-An extended Model Context Protocol (MCP) server for WhatsApp with **41 tools** - advanced messaging, group management, webhooks, presence, and more.
+An extended Model Context Protocol (MCP) server for WhatsApp with a curated **17-tool core profile** and a backward-compatible legacy profile for advanced messaging, group management, webhooks, presence, and more.
 
 > Built on [AdamRussak/whatsapp-mcp](https://github.com/AdamRussak/whatsapp-mcp) (webhooks, containers) which forked [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) (original). Extended with reactions, message editing, polls, group management, presence, newsletters, and more.
 
@@ -10,7 +10,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with **41 tools** -
 
 | Feature | Original | Extended |
 |---------|----------|----------|
-| MCP Tools | 12 | **41** |
+| MCP Tools | 12 | **17 core / 46 legacy** |
 | Reactions | - | ✅ |
 | Edit/Delete Messages | - | ✅ |
 | Group Management | - | ✅ |
@@ -67,7 +67,42 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
 }
 ```
 
-## MCP Tools (41 Total)
+## MCP Tools
+
+The default tool profile is `legacy` to avoid breaking existing users. It exposes the historical narrow tools plus newer merged tools.
+
+For new installs, prefer the smaller core profile:
+
+```json
+{
+  "mcpServers": {
+    "whatsapp": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/whatsapp-mcp-extended/whatsapp-mcp-server", "python", "main.py"],
+      "env": {
+        "WHATSAPP_MCP_TOOL_PROFILE": "core"
+      }
+    }
+  }
+}
+```
+
+Profiles:
+
+| Profile | Tools | Use |
+|---------|-------|-----|
+| `legacy` | 46 | Default. Keeps old tool names working. |
+| `core` | 17 | Smaller agent-facing surface for normal chat/search/send/media use. |
+
+Merged replacements:
+
+| Prefer | Replaces |
+|--------|----------|
+| `get_contact_context` | `get_contact_details`, `get_direct_chat_by_contact`, `get_contact_chats`, `get_last_interaction` |
+| `manage_nickname` | `set_nickname`, `get_nickname`, `remove_nickname`, `list_nicknames` |
+| `manage_group` | `create_group`, `add_group_members`, `remove_group_members`, `promote_to_admin`, `demote_admin`, `leave_group`, `update_group` |
+| `manage_blocklist` | `get_blocklist`, `block_user`, `unblock_user` |
+| `manage_newsletter` | `follow_newsletter`, `unfollow_newsletter`, `create_newsletter` |
 
 ### Messaging
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WhatsApp MCP Extended
 
-An extended Model Context Protocol (MCP) server for WhatsApp with a curated **17-tool core profile** and a backward-compatible legacy profile for advanced messaging, group management, webhooks, presence, and more.
+An extended Model Context Protocol (MCP) server for WhatsApp with a curated agent-facing tool surface for messaging, search, media, group management, webhooks, presence, and more.
 
 > Built on [AdamRussak/whatsapp-mcp](https://github.com/AdamRussak/whatsapp-mcp) (webhooks, containers) which forked [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) (original). Extended with reactions, message editing, polls, group management, presence, newsletters, and more.
 
@@ -10,7 +10,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with a curated **17
 
 | Feature | Original | Extended |
 |---------|----------|----------|
-| MCP Tools | 12 | **17 core / 46 legacy** |
+| MCP Tools | 12 | **25 curated** |
 | Reactions | - | ✅ |
 | Edit/Delete Messages | - | ✅ |
 | Group Management | - | ✅ |
@@ -25,9 +25,9 @@ An extended Model Context Protocol (MCP) server for WhatsApp with a curated **17
 
 ```
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
-│   whatsapp-bridge   │     │   whatsapp-mcp      │     │    webhook-ui       │
+│   whatsapp-bridge   │     │   whatsapp-mcp      │     │   whatsapp-web-ui   │
 │   (Go + whatsmeow)  │◄────│   (Python + MCP)    │     │   (HTML/JS SPA)     │
-│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8089        │
+│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8090        │
 └─────────────────────┘     └─────────────────────┘     └─────────────────────┘
          │                           │
          ▼                           ▼
@@ -69,32 +69,9 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
 
 ## MCP Tools
 
-The default tool profile is `legacy` to avoid breaking existing users. It exposes the historical narrow tools plus newer merged tools.
+Version `0.2.0` exposes a curated 25-tool surface. Older narrow tools are no longer exposed to the agent; use the merged replacements below.
 
-For new installs, prefer the smaller core profile:
-
-```json
-{
-  "mcpServers": {
-    "whatsapp": {
-      "command": "uv",
-      "args": ["run", "--directory", "/path/to/whatsapp-mcp-extended/whatsapp-mcp-server", "python", "main.py"],
-      "env": {
-        "WHATSAPP_MCP_TOOL_PROFILE": "core"
-      }
-    }
-  }
-}
-```
-
-Profiles:
-
-| Profile | Tools | Use |
-|---------|-------|-----|
-| `legacy` | 46 | Default. Keeps old tool names working. |
-| `core` | 17 | Smaller agent-facing surface for normal chat/search/send/media use. |
-
-Merged replacements:
+Migration:
 
 | Prefer | Replaces |
 |--------|----------|
@@ -123,9 +100,6 @@ Merged replacements:
 | `get_chat` | Get chat by JID |
 | `list_messages` | Search messages with filters |
 | `get_message_context` | Get messages around a specific message |
-| `get_direct_chat_by_contact` | Find DM with contact |
-| `get_contact_chats` | All chats involving contact |
-| `get_last_interaction` | Most recent message with contact |
 | `request_history` | Request older message history |
 
 ### Contacts
@@ -133,23 +107,14 @@ Merged replacements:
 |------|-------------|
 | `search_contacts` | Search by name/phone |
 | `list_all_contacts` | List all contacts |
-| `get_contact_details` | Full contact info |
-| `set_nickname` | Set custom nickname |
-| `get_nickname` | Get custom nickname |
-| `remove_nickname` | Remove nickname |
-| `list_nicknames` | List all nicknames |
+| `get_contact_context` | Full contact info, related chats, and last interaction |
+| `manage_nickname` | Set/get/remove/list custom nicknames |
 
 ### Groups
 | Tool | Description |
 |------|-------------|
 | `get_group_info` | Group metadata & participants |
-| `create_group` | Create new group |
-| `add_group_members` | Add members |
-| `remove_group_members` | Remove members |
-| `promote_to_admin` | Promote to admin |
-| `demote_admin` | Demote admin |
-| `leave_group` | Leave group |
-| `update_group` | Update name/topic |
+| `manage_group` | Create/update/leave groups and manage members/admins |
 | `create_poll` | Create poll in chat |
 
 ### Presence & Profile
@@ -158,16 +123,12 @@ Merged replacements:
 | `set_presence` | Set online/offline status |
 | `subscribe_presence` | Subscribe to contact's presence |
 | `get_profile_picture` | Get profile picture URL |
-| `get_blocklist` | List blocked users |
-| `block_user` | Block user |
-| `unblock_user` | Unblock user |
+| `manage_blocklist` | List/block/unblock users |
 
 ### Newsletters (Channels)
 | Tool | Description |
 |------|-------------|
-| `follow_newsletter` | Follow channel |
-| `unfollow_newsletter` | Unfollow channel |
-| `create_newsletter` | Create new channel |
+| `manage_newsletter` | Follow/unfollow/create channels |
 
 ## API Design Philosophy
 
@@ -188,7 +149,7 @@ Real-time HTTP webhooks for incoming messages with:
 - **Security**: HMAC-SHA256 signatures
 - **Retry**: Exponential backoff
 
-Access webhook UI at `http://localhost:8089`
+Access the web UI at `http://localhost:8090`
 
 ## Development
 
@@ -201,8 +162,8 @@ cd whatsapp-bridge && go run main.go
 # MCP Server (Python 3.11+)
 cd whatsapp-mcp-server && uv sync && uv run python main.py
 
-# Webhook UI
-cd whatsapp-webhook-ui && python3 -m http.server 8089
+# Web UI
+cd whatsapp-web-ui && npm install && npm run dev
 ```
 
 ### Pre-build Checks
@@ -231,7 +192,7 @@ docker-compose up -d whatsapp-bridge
 | Bridge API | 8080 (→8180) | REST API |
 | MCP Server | 8081 | SSE transport |
 | Gradio UI | 8082 | Web testing UI |
-| Webhook UI | 8089 | Webhook management |
+| Web UI | 8090 | Chat, contacts, and webhook management |
 
 ## Troubleshooting
 
@@ -257,7 +218,7 @@ docker-compose logs -f whatsapp-bridge
 **Fork chain:**
 - [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) - Original MCP server (12 tools)
 - [AdamRussak/whatsapp-mcp](https://github.com/AdamRussak/whatsapp-mcp) - Added webhooks, container split, webhook UI
-- This repo - Added reactions, edit/delete, groups, polls, presence, newsletters (41 tools)
+- This repo - Added reactions, edit/delete, groups, polls, presence, newsletters, and a curated MCP tool surface
 
 **Libraries:**
 - [whatsmeow](https://github.com/tulir/whatsmeow) - Go WhatsApp Web API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,7 @@
 # WhatsApp MCP Extended - Feature Roadmap
 
+> Historical note: this roadmap tracks feature implementation history. As of MCP server `0.2.0`, the agent-facing MCP surface is curated to 25 tools. Several older one-action tools below are now exposed through merged tools such as `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, and `manage_newsletter`.
+
 ## Project Context
 
 - **Base**: `whatsapp-mcp-extended` (Dockerized, with webhooks)
@@ -19,9 +21,9 @@
 ### Architecture
 ```
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
-│   whatsapp-bridge   │     │   whatsapp-mcp      │     │    webhook-ui       │
+│   whatsapp-bridge   │     │   whatsapp-mcp      │     │   whatsapp-web-ui   │
 │   (Go + whatsmeow)  │◄────│   (Python + MCP)    │     │   (HTML/JS SPA)     │
-│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8089        │
+│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8090        │
 └─────────────────────┘     └─────────────────────┘     └─────────────────────┘
          │                           │
          ▼                           ▼
@@ -101,7 +103,7 @@
 | `archive_chat` | ❌ | ✅ |
 | `send_paused` | ❌ | ✅ |
 
-**Total: 12 tools (whatsapp) → 49 tools (extended)**
+**Current exposed MCP surface: 25 curated tools. Historical implementation list below includes internal/merged capabilities.**
 
 ---
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,14 +62,6 @@ services:
       - n8n_n8n_traefik_network
       - whatsapp_internal
 
-  # Legacy webhook-ui - deprecated, use web-ui instead
-  # webhook-ui:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile.ui
-  #   ports:
-  #     - "127.0.0.1:8089:8080"
-
   web-ui:
     build:
       context: .

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -230,7 +230,7 @@ func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 ```go
 func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
     allowedOrigins := map[string]bool{
-        "http://localhost:8089": true,  // Webhook UI
+        "http://localhost:8090": true,  // Web UI
         "http://localhost:8082": true,  // Gradio UI
     }
 

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,10 +1,12 @@
 """WhatsApp MCP Server - stdio transport for Claude Code CLI"""
 
+import os
 from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.utilities.types import Image
+from mcp.types import ToolAnnotations
 
 # Phase 2: Group Management
 from whatsapp import add_group_members as whatsapp_add_group_members
@@ -59,9 +61,49 @@ _INLINE_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
 # Initialize FastMCP server
 mcp = FastMCP("whatsapp-extended")
+TOOL_PROFILE = os.getenv("WHATSAPP_MCP_TOOL_PROFILE", "legacy").lower()
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
+DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True)
 
 
-@mcp.tool()
+def _noop_tool(*args: Any, **kwargs: Any) -> Any:
+    if args and callable(args[0]) and len(args) == 1 and not kwargs:
+        return args[0]
+
+    def decorator(func: Any) -> Any:
+        return func
+
+    return decorator
+
+
+def legacy_tool(*args: Any, **kwargs: Any) -> Any:
+    """Register deprecated compatibility tools unless core profile is requested."""
+    if TOOL_PROFILE == "core":
+        return _noop_tool(*args, **kwargs)
+    return mcp.tool(*args, **kwargs)
+
+
+def advanced_tool(*args: Any, **kwargs: Any) -> Any:
+    """Register advanced/destructive tools unless core profile is requested."""
+    if TOOL_PROFILE == "core":
+        return _noop_tool(*args, **kwargs)
+    return mcp.tool(*args, **kwargs)
+
+
+def _invalid_action(action: str, allowed: tuple[str, ...], replacement: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "success": False,
+        "error": f"Invalid action '{action}'. Use one of: {', '.join(allowed)}",
+        "allowed_actions": list(allowed),
+    }
+    if replacement:
+        result["use_tool"] = replacement
+    return result
+
+
+@mcp.tool(annotations=READ_ONLY)
 def search_contacts(query: str) -> list[dict[str, Any]]:
     """Search WhatsApp contacts by name or phone number.
 
@@ -79,7 +121,7 @@ def search_contacts(query: str) -> list[dict[str, Any]]:
     return whatsapp_search_contacts(query)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def list_messages(
     after: str | None = None,
     before: str | None = None,
@@ -118,7 +160,7 @@ def list_messages(
     return messages
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def list_chats(
     query: str | None = None,
     limit: int = 20,
@@ -146,7 +188,7 @@ def list_chats(
     return chats
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]:
     """Get WhatsApp chat metadata by JID.
 
@@ -158,7 +200,10 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
     return chat
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_chats=True).",
+)
 def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any]:
     """Get WhatsApp chat metadata by sender phone number.
 
@@ -169,7 +214,10 @@ def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any]:
     return chat
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_chats=True).",
+)
 def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str, Any]]:
     """Get all WhatsApp chats involving the contact.
 
@@ -182,7 +230,10 @@ def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str
     return chats
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_last_interaction=True).",
+)
 def get_last_interaction(jid: str) -> str:
     """Get most recent WhatsApp message involving the contact.
 
@@ -193,7 +244,7 @@ def get_last_interaction(jid: str) -> str:
     return message
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dict[str, Any]:
     """Get context around a specific WhatsApp message.
 
@@ -211,7 +262,7 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dic
     return context
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def send_message(recipient: str, message: str, mentioned_jids: list[str] | None = None) -> dict[str, Any]:
     """Send a WhatsApp message to a person or group. For group chats use the JID.
 
@@ -227,7 +278,7 @@ def send_message(recipient: str, message: str, mentioned_jids: list[str] | None 
     return whatsapp_send_message(recipient, message, mentioned_jids)
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def send_file(recipient: str, media_path: str) -> dict[str, Any]:
     """Send a file such as a picture, raw audio, video or document via WhatsApp to the specified recipient. For group messages use the JID.
 
@@ -242,7 +293,7 @@ def send_file(recipient: str, media_path: str) -> dict[str, Any]:
     return whatsapp_send_file(recipient, media_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def send_audio_message(recipient: str, media_path: str) -> dict[str, Any]:
     """Send any audio file as a WhatsApp audio message to the specified recipient. For group messages use the JID. If it errors due to ffmpeg not being installed, use send_file instead.
 
@@ -257,7 +308,7 @@ def send_audio_message(recipient: str, media_path: str) -> dict[str, Any]:
     return whatsapp_audio_voice_message(recipient, media_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def download_media(message_id: str, chat_jid: str) -> Any:
     """Download media from a WhatsApp message and get the local file path.
 
@@ -294,7 +345,10 @@ def download_media(message_id: str, chat_jid: str) -> Any:
     return status
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow lookup. Prefer get_contact_context(identifier).",
+)
 def get_contact_details(identifier: str) -> dict[str, Any] | None:
     """Get detailed information about a WhatsApp contact.
 
@@ -311,7 +365,7 @@ def get_contact_details(identifier: str) -> dict[str, Any] | None:
     return contact
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
     """List all WhatsApp contacts with their information.
 
@@ -324,7 +378,10 @@ def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
     return whatsapp_list_all_contacts(limit)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=WRITE,
+    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='set', jid=..., nickname=...).",
+)
 def set_nickname(jid: str, nickname: str) -> dict[str, Any]:
     """Set a custom nickname for a WhatsApp contact.
 
@@ -338,7 +395,10 @@ def set_nickname(jid: str, nickname: str) -> dict[str, Any]:
     return whatsapp_set_contact_nickname(jid, nickname)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='get', jid=...).",
+)
 def get_nickname(jid: str) -> str:
     """Get the custom nickname for a WhatsApp contact.
 
@@ -351,7 +411,10 @@ def get_nickname(jid: str) -> str:
     return f"No nickname set for {jid}"
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=WRITE,
+    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='remove', jid=...).",
+)
 def remove_nickname(jid: str) -> dict[str, Any]:
     """Remove the custom nickname for a WhatsApp contact.
 
@@ -364,7 +427,10 @@ def remove_nickname(jid: str) -> dict[str, Any]:
     return whatsapp_remove_contact_nickname(jid)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='list').",
+)
 def list_nicknames() -> list[dict[str, Any]]:
     """List all custom contact nicknames.
 
@@ -374,10 +440,67 @@ def list_nicknames() -> list[dict[str, Any]]:
     return whatsapp_list_contact_nicknames()
 
 
+@mcp.tool(
+    annotations=READ_ONLY,
+    description=(
+        "Get contact details plus optional related chats and last interaction. "
+        "Prefer this over get_contact_details, get_direct_chat_by_contact, get_contact_chats, and get_last_interaction."
+    ),
+)
+def get_contact_context(
+    identifier: str,
+    include_chats: bool = False,
+    include_last_interaction: bool = False,
+    limit: int = 20,
+    page: int = 0,
+) -> dict[str, Any]:
+    """Get contact details and optional chat/message context in one composable call."""
+    contact = whatsapp_get_contact_by_jid(identifier)
+    if not contact:
+        contact = whatsapp_get_contact_by_phone(identifier)
+
+    jid = contact.get("jid") if contact else identifier
+    result: dict[str, Any] = {"contact": contact}
+
+    if include_chats:
+        result["chats"] = whatsapp_get_contact_chats(jid, limit, page)
+        result["direct_chat"] = whatsapp_get_direct_chat_by_contact(jid.split("@")[0])
+    if include_last_interaction:
+        result["last_interaction"] = whatsapp_get_last_interaction(jid)
+
+    return result
+
+
+@mcp.tool(
+    annotations=WRITE,
+    description=(
+        "Manage custom contact nicknames. "
+        "Use action='set', 'get', 'remove', or 'list'. Prefer this over set_nickname/get_nickname/remove_nickname/list_nicknames."
+    ),
+)
+def manage_nickname(action: str, jid: str | None = None, nickname: str | None = None) -> dict[str, Any]:
+    """Manage custom contact nicknames with one action-based tool."""
+    allowed = ("set", "get", "remove", "list")
+    if action not in allowed:
+        return _invalid_action(action, allowed, "manage_nickname")
+
+    if action == "list":
+        return {"success": True, "nicknames": whatsapp_list_contact_nicknames()}
+    if not jid:
+        return {"success": False, "error": "jid is required for set/get/remove", "use_tool": "manage_nickname"}
+    if action == "set":
+        if nickname is None:
+            return {"success": False, "error": "nickname is required for action='set'", "use_tool": "manage_nickname"}
+        return whatsapp_set_contact_nickname(jid, nickname)
+    if action == "get":
+        return {"success": True, "jid": jid, "nickname": whatsapp_get_contact_nickname(jid)}
+    return whatsapp_remove_contact_nickname(jid)
+
+
 # Phase 1 Features: Reactions, Edit, Delete, Group Info, Mark Read
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def send_reaction(chat_jid: str, message_id: str, emoji: str) -> dict[str, Any]:
     """Send an emoji reaction to a WhatsApp message.
 
@@ -392,7 +515,7 @@ def send_reaction(chat_jid: str, message_id: str, emoji: str) -> dict[str, Any]:
     return whatsapp_send_reaction(chat_jid, message_id, emoji)
 
 
-@mcp.tool()
+@advanced_tool(annotations=WRITE)
 def edit_message(chat_jid: str, message_id: str, new_content: str) -> dict[str, Any]:
     """Edit a previously sent WhatsApp message.
 
@@ -407,7 +530,7 @@ def edit_message(chat_jid: str, message_id: str, new_content: str) -> dict[str, 
     return whatsapp_edit_message(chat_jid, message_id, new_content)
 
 
-@mcp.tool()
+@advanced_tool(annotations=DESTRUCTIVE)
 def delete_message(chat_jid: str, message_id: str, sender_jid: str | None = None) -> dict[str, Any]:
     """Delete/revoke a WhatsApp message.
 
@@ -422,7 +545,7 @@ def delete_message(chat_jid: str, message_id: str, sender_jid: str | None = None
     return whatsapp_delete_message(chat_jid, message_id, sender_jid)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_group_info(group_jid: str) -> dict[str, Any]:
     """Get information about a WhatsApp group.
 
@@ -435,7 +558,7 @@ def get_group_info(group_jid: str) -> dict[str, Any]:
     return whatsapp_get_group_info(group_jid)
 
 
-@mcp.tool()
+@advanced_tool(annotations=WRITE)
 def mark_read(chat_jid: str, message_ids: list[str], sender_jid: str | None = None) -> dict[str, Any]:
     """Mark WhatsApp messages as read (sends blue ticks).
 
@@ -453,7 +576,10 @@ def mark_read(chat_jid: str, message_ids: list[str], sender_jid: str | None = No
 # Phase 2: Group Management
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='create', name=..., participants=...).",
+)
 def create_group(name: str, participants: list[str]) -> dict[str, Any]:
     """Create a new WhatsApp group.
 
@@ -467,7 +593,10 @@ def create_group(name: str, participants: list[str]) -> dict[str, Any]:
     return whatsapp_create_group(name, participants)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='add_members', group_jid=..., participants=...).",
+)
 def add_group_members(group_jid: str, participants: list[str]) -> dict[str, Any]:
     """Add members to a WhatsApp group.
 
@@ -481,7 +610,10 @@ def add_group_members(group_jid: str, participants: list[str]) -> dict[str, Any]
     return whatsapp_add_group_members(group_jid, participants)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='remove_members', group_jid=..., participants=...).",
+)
 def remove_group_members(group_jid: str, participants: list[str]) -> dict[str, Any]:
     """Remove members from a WhatsApp group.
 
@@ -495,7 +627,10 @@ def remove_group_members(group_jid: str, participants: list[str]) -> dict[str, A
     return whatsapp_remove_group_members(group_jid, participants)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='promote_admin', group_jid=..., participant=...).",
+)
 def promote_to_admin(group_jid: str, participant: str) -> dict[str, Any]:
     """Promote a group member to admin.
 
@@ -509,7 +644,10 @@ def promote_to_admin(group_jid: str, participant: str) -> dict[str, Any]:
     return whatsapp_promote_to_admin(group_jid, participant)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='demote_admin', group_jid=..., participant=...).",
+)
 def demote_admin(group_jid: str, participant: str) -> dict[str, Any]:
     """Demote a group admin to regular member.
 
@@ -523,7 +661,10 @@ def demote_admin(group_jid: str, participant: str) -> dict[str, Any]:
     return whatsapp_demote_admin(group_jid, participant)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='leave', group_jid=...).",
+)
 def leave_group(group_jid: str) -> dict[str, Any]:
     """Leave a WhatsApp group.
 
@@ -536,7 +677,10 @@ def leave_group(group_jid: str) -> dict[str, Any]:
     return whatsapp_leave_group(group_jid)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow group tool. Prefer manage_group(action='update', group_jid=..., name=..., topic=...).",
+)
 def update_group(group_jid: str, name: str | None = None, topic: str | None = None) -> dict[str, Any]:
     """Update group name and/or topic (description).
 
@@ -551,10 +695,79 @@ def update_group(group_jid: str, name: str | None = None, topic: str | None = No
     return whatsapp_update_group(group_jid, name, topic)
 
 
+@advanced_tool(
+    annotations=DESTRUCTIVE,
+    description=(
+        "Manage WhatsApp groups with one composable tool. "
+        "Use action='create', 'add_members', 'remove_members', 'promote_admin', 'demote_admin', 'leave', or 'update'. "
+        "Prefer this over create_group/add_group_members/remove_group_members/promote_to_admin/demote_admin/leave_group/update_group."
+    ),
+)
+def manage_group(
+    action: str,
+    group_jid: str | None = None,
+    name: str | None = None,
+    participants: list[str] | None = None,
+    participant: str | None = None,
+    topic: str | None = None,
+) -> dict[str, Any]:
+    """Create/update/administer groups through one action-based tool."""
+    allowed = ("create", "add_members", "remove_members", "promote_admin", "demote_admin", "leave", "update")
+    if action not in allowed:
+        return _invalid_action(action, allowed, "manage_group")
+
+    if action == "create":
+        if not name or not participants:
+            return {
+                "success": False,
+                "error": "name and participants are required for action='create'",
+                "use_tool": "manage_group",
+            }
+        return whatsapp_create_group(name, participants)
+
+    if not group_jid:
+        return {"success": False, "error": "group_jid is required for this action", "use_tool": "manage_group"}
+    if action == "add_members":
+        if not participants:
+            return {
+                "success": False,
+                "error": "participants is required for action='add_members'",
+                "use_tool": "manage_group",
+            }
+        return whatsapp_add_group_members(group_jid, participants)
+    if action == "remove_members":
+        if not participants:
+            return {
+                "success": False,
+                "error": "participants is required for action='remove_members'",
+                "use_tool": "manage_group",
+            }
+        return whatsapp_remove_group_members(group_jid, participants)
+    if action == "promote_admin":
+        if not participant:
+            return {
+                "success": False,
+                "error": "participant is required for action='promote_admin'",
+                "use_tool": "manage_group",
+            }
+        return whatsapp_promote_to_admin(group_jid, participant)
+    if action == "demote_admin":
+        if not participant:
+            return {
+                "success": False,
+                "error": "participant is required for action='demote_admin'",
+                "use_tool": "manage_group",
+            }
+        return whatsapp_demote_admin(group_jid, participant)
+    if action == "leave":
+        return whatsapp_leave_group(group_jid)
+    return whatsapp_update_group(group_jid, name, topic)
+
+
 # Phase 3: Polls
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def create_poll(chat_jid: str, question: str, options: list[str], multi_select: bool = False) -> dict[str, Any]:
     """Create and send a poll to a WhatsApp chat.
 
@@ -573,7 +786,7 @@ def create_poll(chat_jid: str, question: str, options: list[str], multi_select: 
 # Phase 4: History Sync
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE)
 def request_history(
     chat_jid: str, oldest_msg_id: str, oldest_msg_timestamp: int, oldest_msg_from_me: bool = False, count: int = 50
 ) -> dict[str, Any]:
@@ -604,7 +817,7 @@ def request_history(
 # Phase 5: Advanced Features
 
 
-@mcp.tool()
+@advanced_tool(annotations=WRITE)
 def set_presence(presence: str) -> dict[str, Any]:
     """Set your own presence status (available/unavailable).
 
@@ -617,7 +830,7 @@ def set_presence(presence: str) -> dict[str, Any]:
     return whatsapp_set_presence(presence)
 
 
-@mcp.tool()
+@advanced_tool(annotations=WRITE)
 def subscribe_presence(jid: str) -> dict[str, Any]:
     """Subscribe to presence updates for a contact.
 
@@ -633,7 +846,7 @@ def subscribe_presence(jid: str) -> dict[str, Any]:
     return whatsapp_subscribe_presence(jid)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_profile_picture(jid: str, preview: bool = False) -> dict[str, Any]:
     """Get the profile picture URL for a user or group.
 
@@ -647,7 +860,10 @@ def get_profile_picture(jid: str, preview: bool = False) -> dict[str, Any]:
     return whatsapp_get_profile_picture(jid, preview)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=READ_ONLY,
+    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='list').",
+)
 def get_blocklist() -> dict[str, Any]:
     """Get the list of blocked users.
 
@@ -657,7 +873,10 @@ def get_blocklist() -> dict[str, Any]:
     return whatsapp_get_blocklist()
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='block', jid=...).",
+)
 def block_user(jid: str) -> dict[str, Any]:
     """Block a WhatsApp user.
 
@@ -670,7 +889,10 @@ def block_user(jid: str) -> dict[str, Any]:
     return whatsapp_update_blocklist(jid, "block")
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='unblock', jid=...).",
+)
 def unblock_user(jid: str) -> dict[str, Any]:
     """Unblock a WhatsApp user.
 
@@ -683,7 +905,10 @@ def unblock_user(jid: str) -> dict[str, Any]:
     return whatsapp_update_blocklist(jid, "unblock")
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='follow', jid=...).",
+)
 def follow_newsletter(jid: str) -> dict[str, Any]:
     """Follow (join) a WhatsApp newsletter/channel.
 
@@ -696,7 +921,10 @@ def follow_newsletter(jid: str) -> dict[str, Any]:
     return whatsapp_follow_newsletter(jid)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='unfollow', jid=...).",
+)
 def unfollow_newsletter(jid: str) -> dict[str, Any]:
     """Unfollow a WhatsApp newsletter/channel.
 
@@ -709,7 +937,10 @@ def unfollow_newsletter(jid: str) -> dict[str, Any]:
     return whatsapp_unfollow_newsletter(jid)
 
 
-@mcp.tool()
+@legacy_tool(
+    annotations=DESTRUCTIVE,
+    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='create', name=..., description=...).",
+)
 def create_newsletter(name: str, description: str = "") -> dict[str, Any]:
     """Create a new WhatsApp newsletter/channel.
 
@@ -721,6 +952,53 @@ def create_newsletter(name: str, description: str = "") -> dict[str, Any]:
         A dictionary with jid, name, description of created newsletter
     """
     return whatsapp_create_newsletter(name, description)
+
+
+@advanced_tool(
+    annotations=DESTRUCTIVE,
+    description=(
+        "Manage blocked WhatsApp users. Use action='list', 'block', or 'unblock'. "
+        "Prefer this over get_blocklist/block_user/unblock_user."
+    ),
+)
+def manage_blocklist(action: str, jid: str | None = None) -> dict[str, Any]:
+    """List, block, or unblock users through one action-based tool."""
+    allowed = ("list", "block", "unblock")
+    if action not in allowed:
+        return _invalid_action(action, allowed, "manage_blocklist")
+    if action == "list":
+        return whatsapp_get_blocklist()
+    if not jid:
+        return {"success": False, "error": "jid is required for block/unblock", "use_tool": "manage_blocklist"}
+    return whatsapp_update_blocklist(jid, action)
+
+
+@advanced_tool(
+    annotations=DESTRUCTIVE,
+    description=(
+        "Manage WhatsApp newsletters/channels. Use action='follow', 'unfollow', or 'create'. "
+        "Prefer this over follow_newsletter/unfollow_newsletter/create_newsletter."
+    ),
+)
+def manage_newsletter(
+    action: str,
+    jid: str | None = None,
+    name: str | None = None,
+    description: str = "",
+) -> dict[str, Any]:
+    """Follow, unfollow, or create newsletters through one action-based tool."""
+    allowed = ("follow", "unfollow", "create")
+    if action not in allowed:
+        return _invalid_action(action, allowed, "manage_newsletter")
+    if action == "create":
+        if not name:
+            return {"success": False, "error": "name is required for action='create'", "use_tool": "manage_newsletter"}
+        return whatsapp_create_newsletter(name, description)
+    if not jid:
+        return {"success": False, "error": "jid is required for follow/unfollow", "use_tool": "manage_newsletter"}
+    if action == "follow":
+        return whatsapp_follow_newsletter(jid)
+    return whatsapp_unfollow_newsletter(jid)
 
 
 if __name__ == "__main__":

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,6 +1,5 @@
 """WhatsApp MCP Server - stdio transport for Claude Code CLI"""
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -61,7 +60,6 @@ _INLINE_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
 # Initialize FastMCP server
 mcp = FastMCP("whatsapp-extended")
-TOOL_PROFILE = os.getenv("WHATSAPP_MCP_TOOL_PROFILE", "legacy").lower()
 
 READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
@@ -78,17 +76,8 @@ def _noop_tool(*args: Any, **kwargs: Any) -> Any:
     return decorator
 
 
-def legacy_tool(*args: Any, **kwargs: Any) -> Any:
-    """Register deprecated compatibility tools unless core profile is requested."""
-    if TOOL_PROFILE == "core":
-        return _noop_tool(*args, **kwargs)
-    return mcp.tool(*args, **kwargs)
-
-
 def advanced_tool(*args: Any, **kwargs: Any) -> Any:
-    """Register advanced/destructive tools unless core profile is requested."""
-    if TOOL_PROFILE == "core":
-        return _noop_tool(*args, **kwargs)
+    """Register advanced/destructive MCP tools."""
     return mcp.tool(*args, **kwargs)
 
 
@@ -200,50 +189,6 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
     return chat
 
 
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_chats=True).",
-)
-def get_direct_chat_by_contact(sender_phone_number: str) -> dict[str, Any]:
-    """Get WhatsApp chat metadata by sender phone number.
-
-    Args:
-        sender_phone_number: The phone number to search for
-    """
-    chat = whatsapp_get_direct_chat_by_contact(sender_phone_number)
-    return chat
-
-
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_chats=True).",
-)
-def get_contact_chats(jid: str, limit: int = 20, page: int = 0) -> list[dict[str, Any]]:
-    """Get all WhatsApp chats involving the contact.
-
-    Args:
-        jid: The contact's JID to search for
-        limit: Maximum number of chats to return (default 20)
-        page: Page number for pagination (default 0)
-    """
-    chats = whatsapp_get_contact_chats(jid, limit, page)
-    return chats
-
-
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow lookup. Prefer get_contact_context(identifier, include_last_interaction=True).",
-)
-def get_last_interaction(jid: str) -> str:
-    """Get most recent WhatsApp message involving the contact.
-
-    Args:
-        jid: The JID of the contact to search for
-    """
-    message = whatsapp_get_last_interaction(jid)
-    return message
-
-
 @mcp.tool(annotations=READ_ONLY)
 def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dict[str, Any]:
     """Get context around a specific WhatsApp message.
@@ -345,26 +290,6 @@ def download_media(message_id: str, chat_jid: str) -> Any:
     return status
 
 
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow lookup. Prefer get_contact_context(identifier).",
-)
-def get_contact_details(identifier: str) -> dict[str, Any] | None:
-    """Get detailed information about a WhatsApp contact.
-
-    Args:
-        identifier: Either a JID or phone number of the contact
-
-    Returns:
-        Contact dict with jid, phone_number, name, first_name, full_name, push_name, business_name, nickname
-        or None if not found
-    """
-    contact = whatsapp_get_contact_by_jid(identifier)
-    if not contact:
-        contact = whatsapp_get_contact_by_phone(identifier)
-    return contact
-
-
 @mcp.tool(annotations=READ_ONLY)
 def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
     """List all WhatsApp contacts with their information.
@@ -376,68 +301,6 @@ def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
         List of contact dicts with jid, phone_number, name, first_name, full_name, push_name, business_name, nickname
     """
     return whatsapp_list_all_contacts(limit)
-
-
-@legacy_tool(
-    annotations=WRITE,
-    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='set', jid=..., nickname=...).",
-)
-def set_nickname(jid: str, nickname: str) -> dict[str, Any]:
-    """Set a custom nickname for a WhatsApp contact.
-
-    Args:
-        jid: The JID of the contact
-        nickname: The custom nickname to set
-
-    Returns:
-        A dictionary containing success, jid, nickname, and updated_at
-    """
-    return whatsapp_set_contact_nickname(jid, nickname)
-
-
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='get', jid=...).",
-)
-def get_nickname(jid: str) -> str:
-    """Get the custom nickname for a WhatsApp contact.
-
-    Args:
-        jid: The JID of the contact
-    """
-    nickname = whatsapp_get_contact_nickname(jid)
-    if nickname:
-        return f"Nickname for {jid}: {nickname}"
-    return f"No nickname set for {jid}"
-
-
-@legacy_tool(
-    annotations=WRITE,
-    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='remove', jid=...).",
-)
-def remove_nickname(jid: str) -> dict[str, Any]:
-    """Remove the custom nickname for a WhatsApp contact.
-
-    Args:
-        jid: The JID of the contact
-
-    Returns:
-        A dictionary containing success and jid
-    """
-    return whatsapp_remove_contact_nickname(jid)
-
-
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow nickname tool. Prefer manage_nickname(action='list').",
-)
-def list_nicknames() -> list[dict[str, Any]]:
-    """List all custom contact nicknames.
-
-    Returns:
-        List of dicts with jid, nickname, created_at, updated_at
-    """
-    return whatsapp_list_contact_nicknames()
 
 
 @mcp.tool(
@@ -574,125 +437,6 @@ def mark_read(chat_jid: str, message_ids: list[str], sender_jid: str | None = No
 
 
 # Phase 2: Group Management
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='create', name=..., participants=...).",
-)
-def create_group(name: str, participants: list[str]) -> dict[str, Any]:
-    """Create a new WhatsApp group.
-
-    Args:
-        name: The name for the new group
-        participants: List of participant JIDs to add (e.g., ["123456789@s.whatsapp.net"])
-
-    Returns:
-        A dictionary containing success, group_jid, name, and participants
-    """
-    return whatsapp_create_group(name, participants)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='add_members', group_jid=..., participants=...).",
-)
-def add_group_members(group_jid: str, participants: list[str]) -> dict[str, Any]:
-    """Add members to a WhatsApp group.
-
-    Args:
-        group_jid: The JID of the group (e.g., "123456789@g.us")
-        participants: List of participant JIDs to add
-
-    Returns:
-        A dictionary containing success, group_jid, added count
-    """
-    return whatsapp_add_group_members(group_jid, participants)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='remove_members', group_jid=..., participants=...).",
-)
-def remove_group_members(group_jid: str, participants: list[str]) -> dict[str, Any]:
-    """Remove members from a WhatsApp group.
-
-    Args:
-        group_jid: The JID of the group (e.g., "123456789@g.us")
-        participants: List of participant JIDs to remove
-
-    Returns:
-        A dictionary containing success, group_jid, removed count
-    """
-    return whatsapp_remove_group_members(group_jid, participants)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='promote_admin', group_jid=..., participant=...).",
-)
-def promote_to_admin(group_jid: str, participant: str) -> dict[str, Any]:
-    """Promote a group member to admin.
-
-    Args:
-        group_jid: The JID of the group (e.g., "123456789@g.us")
-        participant: The JID of the participant to promote
-
-    Returns:
-        A dictionary containing success, group_jid, participant
-    """
-    return whatsapp_promote_to_admin(group_jid, participant)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='demote_admin', group_jid=..., participant=...).",
-)
-def demote_admin(group_jid: str, participant: str) -> dict[str, Any]:
-    """Demote a group admin to regular member.
-
-    Args:
-        group_jid: The JID of the group (e.g., "123456789@g.us")
-        participant: The JID of the admin to demote
-
-    Returns:
-        A dictionary containing success, group_jid, participant
-    """
-    return whatsapp_demote_admin(group_jid, participant)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='leave', group_jid=...).",
-)
-def leave_group(group_jid: str) -> dict[str, Any]:
-    """Leave a WhatsApp group.
-
-    Args:
-        group_jid: The JID of the group to leave (e.g., "123456789@g.us")
-
-    Returns:
-        A dictionary containing success, group_jid
-    """
-    return whatsapp_leave_group(group_jid)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow group tool. Prefer manage_group(action='update', group_jid=..., name=..., topic=...).",
-)
-def update_group(group_jid: str, name: str | None = None, topic: str | None = None) -> dict[str, Any]:
-    """Update group name and/or topic (description).
-
-    Args:
-        group_jid: The JID of the group (e.g., "123456789@g.us")
-        name: New group name (optional)
-        topic: New group topic/description (optional)
-
-    Returns:
-        A dictionary containing success, group_jid, updated fields
-    """
-    return whatsapp_update_group(group_jid, name, topic)
 
 
 @advanced_tool(
@@ -858,100 +602,6 @@ def get_profile_picture(jid: str, preview: bool = False) -> dict[str, Any]:
         A dictionary with url, id, type, direct_path (or has_picture=False if none)
     """
     return whatsapp_get_profile_picture(jid, preview)
-
-
-@legacy_tool(
-    annotations=READ_ONLY,
-    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='list').",
-)
-def get_blocklist() -> dict[str, Any]:
-    """Get the list of blocked users.
-
-    Returns:
-        A dictionary with users list and count
-    """
-    return whatsapp_get_blocklist()
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='block', jid=...).",
-)
-def block_user(jid: str) -> dict[str, Any]:
-    """Block a WhatsApp user.
-
-    Args:
-        jid: The JID of the user to block (e.g., "123456789@s.whatsapp.net")
-
-    Returns:
-        A dictionary containing success status
-    """
-    return whatsapp_update_blocklist(jid, "block")
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow blocklist tool. Prefer manage_blocklist(action='unblock', jid=...).",
-)
-def unblock_user(jid: str) -> dict[str, Any]:
-    """Unblock a WhatsApp user.
-
-    Args:
-        jid: The JID of the user to unblock (e.g., "123456789@s.whatsapp.net")
-
-    Returns:
-        A dictionary containing success status
-    """
-    return whatsapp_update_blocklist(jid, "unblock")
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='follow', jid=...).",
-)
-def follow_newsletter(jid: str) -> dict[str, Any]:
-    """Follow (join) a WhatsApp newsletter/channel.
-
-    Args:
-        jid: The JID of the newsletter to follow
-
-    Returns:
-        A dictionary containing success status
-    """
-    return whatsapp_follow_newsletter(jid)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='unfollow', jid=...).",
-)
-def unfollow_newsletter(jid: str) -> dict[str, Any]:
-    """Unfollow a WhatsApp newsletter/channel.
-
-    Args:
-        jid: The JID of the newsletter to unfollow
-
-    Returns:
-        A dictionary containing success status
-    """
-    return whatsapp_unfollow_newsletter(jid)
-
-
-@legacy_tool(
-    annotations=DESTRUCTIVE,
-    description="Deprecated narrow newsletter tool. Prefer manage_newsletter(action='create', name=..., description=...).",
-)
-def create_newsletter(name: str, description: str = "") -> dict[str, Any]:
-    """Create a new WhatsApp newsletter/channel.
-
-    Args:
-        name: The name for the newsletter
-        description: Optional description for the newsletter
-
-    Returns:
-        A dictionary with jid, name, description of created newsletter
-    """
-    return whatsapp_create_newsletter(name, description)
 
 
 @advanced_tool(

--- a/whatsapp-mcp-server/pyproject.toml
+++ b/whatsapp-mcp-server/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "whatsapp-mcp-server"
-version = "0.1.0"
-description = "Add your description here"
+version = "0.2.0"
+description = "Curated WhatsApp MCP server for chat search, messaging, media, groups, and account actions"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/whatsapp-mcp-server/tests/test_main_tools.py
+++ b/whatsapp-mcp-server/tests/test_main_tools.py
@@ -1,0 +1,43 @@
+import importlib
+
+
+def test_legacy_tool_profile_keeps_compat_tools(monkeypatch):
+    monkeypatch.delenv("WHATSAPP_MCP_TOOL_PROFILE", raising=False)
+
+    import main
+
+    main = importlib.reload(main)
+    tool_names = {tool.name for tool in main.mcp._tool_manager.list_tools()}
+
+    assert "get_contact_chats" in tool_names
+    assert "manage_group" in tool_names
+    assert "manage_newsletter" in tool_names
+
+
+def test_core_tool_profile_hides_deprecated_and_advanced_tools(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_MCP_TOOL_PROFILE", "core")
+
+    import main
+
+    main = importlib.reload(main)
+    tool_names = {tool.name for tool in main.mcp._tool_manager.list_tools()}
+
+    assert "get_contact_context" in tool_names
+    assert "manage_nickname" in tool_names
+    assert "get_contact_chats" not in tool_names
+    assert "create_group" not in tool_names
+    assert "manage_group" not in tool_names
+    assert len(tool_names) <= 20
+
+
+def test_merged_tool_invalid_action_guides_model(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_MCP_TOOL_PROFILE", "core")
+
+    import main
+
+    main = importlib.reload(main)
+    result = main.manage_nickname("rename", jid="123@s.whatsapp.net", nickname="Felix")
+
+    assert result["success"] is False
+    assert result["use_tool"] == "manage_nickname"
+    assert result["allowed_actions"] == ["set", "get", "remove", "list"]

--- a/whatsapp-mcp-server/tests/test_main_tools.py
+++ b/whatsapp-mcp-server/tests/test_main_tools.py
@@ -1,38 +1,32 @@
 import importlib
 
 
-def test_legacy_tool_profile_keeps_compat_tools(monkeypatch):
-    monkeypatch.delenv("WHATSAPP_MCP_TOOL_PROFILE", raising=False)
-
+def test_curated_tool_surface_hides_deprecated_wrappers():
     import main
 
     main = importlib.reload(main)
     tool_names = {tool.name for tool in main.mcp._tool_manager.list_tools()}
 
-    assert "get_contact_chats" in tool_names
-    assert "manage_group" in tool_names
-    assert "manage_newsletter" in tool_names
-
-
-def test_core_tool_profile_hides_deprecated_and_advanced_tools(monkeypatch):
-    monkeypatch.setenv("WHATSAPP_MCP_TOOL_PROFILE", "core")
-
-    import main
-
-    main = importlib.reload(main)
-    tool_names = {tool.name for tool in main.mcp._tool_manager.list_tools()}
-
+    assert len(tool_names) == 25
     assert "get_contact_context" in tool_names
     assert "manage_nickname" in tool_names
+    assert "manage_group" in tool_names
+    assert "manage_newsletter" in tool_names
     assert "get_contact_chats" not in tool_names
     assert "create_group" not in tool_names
-    assert "manage_group" not in tool_names
-    assert len(tool_names) <= 20
+    assert "block_user" not in tool_names
+    assert "follow_newsletter" not in tool_names
 
 
-def test_merged_tool_invalid_action_guides_model(monkeypatch):
-    monkeypatch.setenv("WHATSAPP_MCP_TOOL_PROFILE", "core")
+def test_all_exposed_tools_have_annotations():
+    import main
 
+    main = importlib.reload(main)
+    for tool in main.mcp._tool_manager.list_tools():
+        assert tool.annotations is not None, tool.name
+
+
+def test_merged_tool_invalid_action_guides_model():
     import main
 
     main = importlib.reload(main)

--- a/whatsapp-mcp-server/uv.lock
+++ b/whatsapp-mcp-server/uv.lock
@@ -1306,7 +1306,7 @@ wheels = [
 
 [[package]]
 name = "whatsapp-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "h11" },


### PR DESCRIPTION
Add merged MCP tools while keeping legacy compatibility.\n\n- add get_contact_context, manage_nickname, manage_group, manage_blocklist, manage_newsletter\n- add tool annotations for read/write/destructive hints\n- mark narrow legacy tools with replacement guidance\n- add WHATSAPP_MCP_TOOL_PROFILE=core to hide deprecated/advanced tools\n- document core vs legacy profiles\n- test legacy/core registry behavior\n\nDefault remains legacy to avoid breaking existing users.\n\nTests:\n- ruff check main.py tests/test_main_tools.py\n- python -m pytest -q