### PR TITLE
MCP toolset gating + Docker image optimisation (2.43GB → 837MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,5 +21,6 @@ whatsapp-web-ui/out/
 whatsapp-bridge/whatsapp-bridge
 
 # Docs / misc
-*.md
+**/*.md
 docs/
+whatsapp-mcp-server/check.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+.git
+.gitignore
+
+# WhatsApp session data — bind mounted at runtime, never needed in build context
+store/
+
+# Python
+whatsapp-mcp-server/.venv/
+whatsapp-mcp-server/__pycache__/
+whatsapp-mcp-server/**/__pycache__/
+whatsapp-mcp-server/**/*.pyc
+whatsapp-mcp-server/.pytest_cache/
+whatsapp-mcp-server/tests/
+
+# Node / Next.js
+whatsapp-web-ui/node_modules/
+whatsapp-web-ui/.next/
+whatsapp-web-ui/out/
+
+# Go build artifacts
+whatsapp-bridge/whatsapp-bridge
+
+# Docs / misc
+*.md
+docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,10 @@ whatsapp-web-ui/     # HTML/JS - Chat/contact/webhook UI
 3. Add Python function in `whatsapp-mcp-server/whatsapp.py`
 4. Prefer extending an existing composable MCP tool in `whatsapp-mcp-server/main.py`
 5. Add a new MCP tool only for a distinct user task, not a one-endpoint wrapper
-6. Add/update `whatsapp-mcp-server/tests/test_main_tools.py`
-7. Update README tool list
+6. Assign the tool to a `WHATSAPP_MCP_TOOLSETS` group and add title/annotations
+7. Use `Literal[...]` for action/sort/status parameters where possible
+8. Add/update `whatsapp-mcp-server/tests/test_main_tools.py`
+9. Update README tool list and migration notes
 
 ## Questions?
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,40 +1,39 @@
-# Dockerfile for WhatsApp MCP Server
-FROM python:3.13 AS runtime
+# Build stage: install deps into isolated venv, keeps build tools out of final image
+FROM python:3.13-slim AS builder
+
+RUN pip install --no-cache-dir uv
 
 WORKDIR /app
+COPY ./whatsapp-mcp-server/requirements.txt .
 
-# Copy the Python MCP project files
-COPY ./whatsapp-mcp-server /app/whatsapp-mcp-server
+# gradio/gradio_client only used in gradio-main.py (local dev UI), not main.py entrypoint
+RUN grep -vE "^gradio" requirements.txt > requirements-docker.txt \
+    && uv venv /opt/venv \
+    && uv pip install --python /opt/venv --no-cache -r requirements-docker.txt
 
-# Install system dependencies
+# Runtime stage: slim base + ffmpeg + venv only, no build tools
+FROM python:3.13-slim AS runtime
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security (UID 1000 to match common host user)
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 ARG UID=1000
 ARG GID=1000
 RUN groupadd -g ${GID} appuser && useradd -l -u ${UID} -g appuser appuser
 
-# Set up Python environment and install dependencies
-RUN python3 -m pip install --upgrade pip uv
+WORKDIR /app
+COPY ./whatsapp-mcp-server /app/whatsapp-mcp-server
 
-# Install dependencies from requirements.txt
-WORKDIR /app/whatsapp-mcp-server
-COPY ./whatsapp-mcp-server/requirements.txt /app/whatsapp-mcp-server/requirements.txt
-RUN pip install -r requirements.txt
-
-# Create directories and entrypoint script
 RUN mkdir -p /app/store /app/media \
     && printf '#!/bin/bash\ncd /app/whatsapp-mcp-server\nexec python main.py\n' > /app/entrypoint-mcp.sh \
     && chmod +x /app/entrypoint-mcp.sh \
     && chown -R appuser:appuser /app
 
-# Switch to non-root user
 USER appuser
-
-# Expose port for MCP server
 EXPOSE 8081
-
 ENTRYPOINT ["/app/entrypoint-mcp.sh"]

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -16,7 +16,6 @@ FROM python:3.13-slim AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -3,7 +3,7 @@ FROM python:3.13 AS runtime
 
 WORKDIR /app
 
-# Copy the Python Gradio project files
+# Copy the Python MCP project files
 COPY ./whatsapp-mcp-server /app/whatsapp-mcp-server
 
 # Install system dependencies
@@ -27,15 +27,14 @@ RUN pip install -r requirements.txt
 
 # Create directories and entrypoint script
 RUN mkdir -p /app/store /app/media \
-    && printf '#!/bin/bash\ncd /app/whatsapp-mcp-server\npython gradio-main.py\n' > /app/entrypoint-mcp.sh \
+    && printf '#!/bin/bash\ncd /app/whatsapp-mcp-server\nexec python main.py\n' > /app/entrypoint-mcp.sh \
     && chmod +x /app/entrypoint-mcp.sh \
     && chown -R appuser:appuser /app
 
 # Switch to non-root user
 USER appuser
 
-# Expose ports for MCP server and Gradio UI
+# Expose port for MCP server
 EXPOSE 8081
-EXPOSE 8082
 
 ENTRYPOINT ["/app/entrypoint-mcp.sh"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with a toolset-gate
 
 | Feature | Original | Extended |
 |---------|----------|----------|
-| MCP Tools | 12 | **15 default / 26 max** |
+| MCP Tools | 12 | **26 default / 15 lean** |
 | Reactions | - | ✅ |
 | Edit/Delete Messages | - | ✅ |
 | Group Management | - | ✅ |
@@ -69,18 +69,18 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
 
 ## MCP Tools
 
-Version `0.2.0` exposes a smaller default MCP surface and opt-in toolsets for advanced/destructive actions.
+Version `0.2.0` exposes the full curated MCP surface by default for compatibility. Users who want a leaner agent context can opt into smaller toolsets.
 
 Default toolsets:
 
 ```bash
-WHATSAPP_MCP_TOOLSETS=core,send,media
+WHATSAPP_MCP_TOOLSETS=all
 ```
 
-Expose every curated tool:
+Lean recommended toolsets:
 
 ```bash
-WHATSAPP_MCP_TOOLSETS=all
+WHATSAPP_MCP_TOOLSETS=core,send,media
 ```
 
 Toolsets:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WhatsApp MCP Extended
 
-An extended Model Context Protocol (MCP) server for WhatsApp with a curated agent-facing tool surface for messaging, search, media, group management, webhooks, presence, and more.
+An extended Model Context Protocol (MCP) server for WhatsApp with a toolset-gated, agent-facing surface for messaging, search, media, group management, webhooks, presence, and more.
 
 > Built on [AdamRussak/whatsapp-mcp](https://github.com/AdamRussak/whatsapp-mcp) (webhooks, containers) which forked [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) (original). Extended with reactions, message editing, polls, group management, presence, newsletters, and more.
 
@@ -10,7 +10,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with a curated agen
 
 | Feature | Original | Extended |
 |---------|----------|----------|
-| MCP Tools | 12 | **25 curated** |
+| MCP Tools | 12 | **15 default / 26 max** |
 | Reactions | - | ✅ |
 | Edit/Delete Messages | - | ✅ |
 | Group Management | - | ✅ |
@@ -27,7 +27,7 @@ An extended Model Context Protocol (MCP) server for WhatsApp with a curated agen
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
 │   whatsapp-bridge   │     │   whatsapp-mcp      │     │   whatsapp-web-ui   │
 │   (Go + whatsmeow)  │◄────│   (Python + MCP)    │     │   (HTML/JS SPA)     │
-│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8090        │
+│   Port: 8080        │     │   Port: 8081        │     │   Port: 8090        │
 └─────────────────────┘     └─────────────────────┘     └─────────────────────┘
          │                           │
          ▼                           ▼
@@ -69,7 +69,38 @@ Add to your MCP config (`claude_desktop_config.json` or Cursor settings):
 
 ## MCP Tools
 
-Version `0.2.0` exposes a curated 25-tool surface. Older narrow tools are no longer exposed to the agent; use the merged replacements below.
+Version `0.2.0` exposes a smaller default MCP surface and opt-in toolsets for advanced/destructive actions.
+
+Default toolsets:
+
+```bash
+WHATSAPP_MCP_TOOLSETS=core,send,media
+```
+
+Expose every curated tool:
+
+```bash
+WHATSAPP_MCP_TOOLSETS=all
+```
+
+Toolsets:
+
+| Toolset | Default | Tools |
+|---------|---------|-------|
+| `core` | Yes | Search/read tools, contact context, group info, profile picture |
+| `send` | Yes | `send_message`, `send_reaction`, `create_poll` |
+| `media` | Yes | `send_file`, `send_audio_message`, `download_media` |
+| `history` | No | `request_history` |
+| `contacts_write` | No | `manage_nickname` |
+| `message_admin` | No | `edit_message`, `delete_message`, `mark_read` |
+| `groups` | No | `manage_group` |
+| `presence` | No | `set_presence`, `subscribe_presence` |
+| `account_admin` | No | `get_blocklist`, `manage_blocklist` |
+| `newsletter` | No | `manage_newsletter` |
+
+You can also expose individual tools with `WHATSAPP_MCP_TOOLS=manage_group,delete_message`.
+
+Breaking change in `0.2.0`: older narrow tools are no longer exposed to the agent. Use the merged replacements below.
 
 Migration:
 
@@ -78,7 +109,7 @@ Migration:
 | `get_contact_context` | `get_contact_details`, `get_direct_chat_by_contact`, `get_contact_chats`, `get_last_interaction` |
 | `manage_nickname` | `set_nickname`, `get_nickname`, `remove_nickname`, `list_nicknames` |
 | `manage_group` | `create_group`, `add_group_members`, `remove_group_members`, `promote_to_admin`, `demote_admin`, `leave_group`, `update_group` |
-| `manage_blocklist` | `get_blocklist`, `block_user`, `unblock_user` |
+| `get_blocklist`, `manage_blocklist` | `get_blocklist`, `block_user`, `unblock_user` |
 | `manage_newsletter` | `follow_newsletter`, `unfollow_newsletter`, `create_newsletter` |
 
 ### Messaging
@@ -123,7 +154,8 @@ Migration:
 | `set_presence` | Set online/offline status |
 | `subscribe_presence` | Subscribe to contact's presence |
 | `get_profile_picture` | Get profile picture URL |
-| `manage_blocklist` | List/block/unblock users |
+| `get_blocklist` | List blocked users |
+| `manage_blocklist` | Block/unblock users |
 
 ### Newsletters (Channels)
 | Tool | Description |
@@ -190,8 +222,7 @@ docker-compose up -d whatsapp-bridge
 | Service | Port | Description |
 |---------|------|-------------|
 | Bridge API | 8080 (→8180) | REST API |
-| MCP Server | 8081 | SSE transport |
-| Gradio UI | 8082 | Web testing UI |
+| MCP Server | 8081 | Streamable HTTP transport |
 | Web UI | 8090 | Chat, contacts, and webhook management |
 
 ## Troubleshooting

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # WhatsApp MCP Extended - Feature Roadmap
 
-> Historical note: this roadmap tracks feature implementation history. As of MCP server `0.2.0`, the agent-facing MCP surface is curated to 25 tools. Several older one-action tools below are now exposed through merged tools such as `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, and `manage_newsletter`.
+> Historical note: this roadmap tracks feature implementation history. As of MCP server `0.2.0`, the default agent-facing MCP surface is toolset-gated to 15 tools, with 26 maximum curated tools via `WHATSAPP_MCP_TOOLSETS=all`. Several older one-action tools below are now exposed through merged tools such as `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, and `manage_newsletter`.
 
 ## Project Context
 
@@ -10,12 +10,10 @@
 
 ## Current State
 
-### Implemented (16+ MCP tools)
-- `search_contacts`, `list_messages`, `list_chats`
-- `get_chat`, `get_direct_chat_by_contact`, `get_contact_chats`
-- `get_last_interaction`, `get_message_context`
-- `send_message`, `send_file`, `send_audio_message`, `download_media`
-- Contact nicknames: `set_contact_nickname`, `get_contact_nickname`, `remove_contact_nickname`, `list_contact_nicknames`
+### Implemented MCP surface
+- Default toolsets: `core`, `send`, `media` (15 tools)
+- Maximum curated surface: 26 tools via `WHATSAPP_MCP_TOOLSETS=all`
+- Merged context/action tools: `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, `manage_newsletter`
 - Webhook system (via REST API)
 
 ### Architecture
@@ -23,7 +21,7 @@
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
 │   whatsapp-bridge   │     │   whatsapp-mcp      │     │   whatsapp-web-ui   │
 │   (Go + whatsmeow)  │◄────│   (Python + MCP)    │     │   (HTML/JS SPA)     │
-│   Port: 8080        │     │   Ports: 8081,8082  │     │   Port: 8090        │
+│   Port: 8080        │     │   Port: 8081        │     │   Port: 8090        │
 └─────────────────────┘     └─────────────────────┘     └─────────────────────┘
          │                           │
          ▼                           ▼
@@ -103,7 +101,7 @@
 | `archive_chat` | ❌ | ✅ |
 | `send_paused` | ❌ | ✅ |
 
-**Current exposed MCP surface: 25 curated tools. Historical implementation list below includes internal/merged capabilities.**
+**Current exposed MCP surface: 15 default tools, 26 maximum curated tools. Historical implementation list below includes internal/merged capabilities.**
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # WhatsApp MCP Extended - Feature Roadmap
 
-> Historical note: this roadmap tracks feature implementation history. As of MCP server `0.2.0`, the default agent-facing MCP surface is toolset-gated to 15 tools, with 26 maximum curated tools via `WHATSAPP_MCP_TOOLSETS=all`. Several older one-action tools below are now exposed through merged tools such as `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, and `manage_newsletter`.
+> Historical note: this roadmap tracks feature implementation history. As of MCP server `0.2.0`, the default agent-facing MCP surface exposes 26 curated tools, while lean installs can opt into 15 tools via `WHATSAPP_MCP_TOOLSETS=core,send,media`. Several older one-action tools below are now exposed through merged tools such as `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, and `manage_newsletter`.
 
 ## Project Context
 
@@ -11,8 +11,8 @@
 ## Current State
 
 ### Implemented MCP surface
-- Default toolsets: `core`, `send`, `media` (15 tools)
-- Maximum curated surface: 26 tools via `WHATSAPP_MCP_TOOLSETS=all`
+- Default toolsets: `all` (26 tools)
+- Lean surface: `core`, `send`, `media` (15 tools)
 - Merged context/action tools: `get_contact_context`, `manage_nickname`, `manage_group`, `manage_blocklist`, `manage_newsletter`
 - Webhook system (via REST API)
 
@@ -101,7 +101,7 @@
 | `archive_chat` | ❌ | ✅ |
 | `send_paused` | ❌ | ✅ |
 
-**Current exposed MCP surface: 15 default tools, 26 maximum curated tools. Historical implementation list below includes internal/merged capabilities.**
+**Current exposed MCP surface: 26 default tools, 15 lean tools. Historical implementation list below includes internal/merged capabilities.**
 
 ---
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - MCP_TRANSPORT=streamable-http
       - HOST=0.0.0.0
       - PORT=8081
-      - WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-core,send,media}
+      - WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-all}
       - BRIDGE_HOST=whatsapp-bridge
       - API_KEY=${API_KEY}
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - API_KEY=${API_KEY:?API_KEY is required - see .env.example}
       - DISABLE_AUTH_CHECK=${DISABLE_AUTH_CHECK:-false}
     healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:8080/api/health"]
       interval: 60s
       timeout: 10s
       retries: 3
@@ -58,7 +58,7 @@ services:
       - BRIDGE_HOST=whatsapp-bridge
       - API_KEY=${API_KEY}
     healthcheck:
-      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', 8081), timeout=3)"]
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8081), timeout=3)"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -83,7 +83,7 @@ services:
     ports:
       - "127.0.0.1:8090:8080"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/"]
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,8 +57,15 @@ services:
       - WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-all}
       - BRIDGE_HOST=whatsapp-bridge
       - API_KEY=${API_KEY}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', 8081), timeout=3)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     depends_on:
-      - whatsapp-bridge
+      whatsapp-bridge:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - n8n_n8n_traefik_network
@@ -75,8 +82,15 @@ services:
           cpus: '0.5'
     ports:
       - "127.0.0.1:8090:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
-      - whatsapp-bridge
+      whatsapp-bridge:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - whatsapp_internal

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - API_KEY=${API_KEY:?API_KEY is required - see .env.example}
       - DISABLE_AUTH_CHECK=${DISABLE_AUTH_CHECK:-false}
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8080/api/health"]
       interval: 60s
       timeout: 10s
       retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,13 +46,15 @@ services:
           cpus: '1'
     ports:
       - "127.0.0.1:8081:8081"  # MCP server (localhost only)
-      - "127.0.0.1:8082:8082"  # Gradio UI (localhost only)
     volumes:
       - ./store:/app/store
     environment:
       - TZ=UTC
       - DEBUG=true
-      - GRADIO=false
+      - MCP_TRANSPORT=streamable-http
+      - HOST=0.0.0.0
+      - PORT=8081
+      - WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-core,send,media}
       - BRIDGE_HOST=whatsapp-bridge
       - API_KEY=${API_KEY}
     depends_on:

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,7 +1,8 @@
 """WhatsApp MCP Server - stdio transport for Claude Code CLI"""
 
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.utilities.types import Image
@@ -61,24 +62,77 @@ _INLINE_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 # Initialize FastMCP server
 mcp = FastMCP("whatsapp-extended")
 
-READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
-WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
-DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True)
+ALL_TOOLSETS = {
+    "core",
+    "send",
+    "media",
+    "history",
+    "contacts_write",
+    "message_admin",
+    "groups",
+    "presence",
+    "account_admin",
+    "newsletter",
+}
+DEFAULT_TOOLSETS = {"core", "send", "media"}
+ENABLED_TOOLSETS = {
+    part.strip().lower()
+    for part in os.getenv("WHATSAPP_MCP_TOOLSETS", ",".join(sorted(DEFAULT_TOOLSETS))).split(",")
+    if part.strip()
+}
+if "all" in ENABLED_TOOLSETS:
+    ENABLED_TOOLSETS = set(ALL_TOOLSETS)
+
+UNKNOWN_TOOLSETS = ENABLED_TOOLSETS - ALL_TOOLSETS
+if UNKNOWN_TOOLSETS:
+    raise ValueError(
+        f"Unknown WHATSAPP_MCP_TOOLSETS values: {', '.join(sorted(UNKNOWN_TOOLSETS))}. "
+        f"Use any of: {', '.join(sorted(ALL_TOOLSETS))}, or all."
+    )
+
+ENABLED_TOOLS = {part.strip() for part in os.getenv("WHATSAPP_MCP_TOOLS", "").split(",") if part.strip()}
+
+NicknameAction = Literal["set", "get", "remove", "list"]
+GroupAction = Literal["create", "add_members", "remove_members", "promote_admin", "demote_admin", "leave", "update"]
+BlocklistAction = Literal["block", "unblock"]
+NewsletterAction = Literal["follow", "unfollow", "create"]
+PresenceState = Literal["available", "unavailable"]
+ChatSort = Literal["last_active", "name"]
 
 
-def _noop_tool(*args: Any, **kwargs: Any) -> Any:
-    if args and callable(args[0]) and len(args) == 1 and not kwargs:
-        return args[0]
+def _tool_enabled(name: str, toolset: str) -> bool:
+    return toolset in ENABLED_TOOLSETS or name in ENABLED_TOOLS
+
+
+def tool(
+    toolset: str,
+    title: str,
+    *,
+    read_only: bool,
+    destructive: bool = False,
+    idempotent: bool = False,
+    open_world: bool = True,
+    description: str | None = None,
+) -> Any:
+    """Register an MCP tool only when its toolset or explicit name is enabled."""
 
     def decorator(func: Any) -> Any:
-        return func
+        if not _tool_enabled(func.__name__, toolset):
+            return func
+
+        return mcp.tool(
+            title=title,
+            description=description,
+            annotations=ToolAnnotations(
+                title=title,
+                readOnlyHint=read_only,
+                destructiveHint=destructive,
+                idempotentHint=idempotent,
+                openWorldHint=open_world,
+            ),
+        )(func)
 
     return decorator
-
-
-def advanced_tool(*args: Any, **kwargs: Any) -> Any:
-    """Register advanced/destructive MCP tools."""
-    return mcp.tool(*args, **kwargs)
 
 
 def _invalid_action(action: str, allowed: tuple[str, ...], replacement: str | None = None) -> dict[str, Any]:
@@ -92,7 +146,7 @@ def _invalid_action(action: str, allowed: tuple[str, ...], replacement: str | No
     return result
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "Search Contacts", read_only=True, idempotent=True, open_world=False)
 def search_contacts(query: str) -> list[dict[str, Any]]:
     """Search WhatsApp contacts by name or phone number.
 
@@ -104,13 +158,12 @@ def search_contacts(query: str) -> list[dict[str, Any]]:
 
     Hints:
         - Use returned jid with `list_messages` to filter messages by contact
-        - Use `get_contact_details` for more detailed contact info
-        - Use `get_last_interaction` to find most recent message with contact
+        - Use `get_contact_context` for detailed contact info, chats, or last interaction
     """
     return whatsapp_search_contacts(query)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "List Messages", read_only=True, idempotent=True, open_world=False)
 def list_messages(
     after: str | None = None,
     before: str | None = None,
@@ -149,13 +202,13 @@ def list_messages(
     return messages
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "List Chats", read_only=True, idempotent=True, open_world=False)
 def list_chats(
     query: str | None = None,
     limit: int = 20,
     page: int = 0,
     include_last_message: bool = True,
-    sort_by: str = "last_active",
+    sort_by: ChatSort = "last_active",
 ) -> list[dict[str, Any]]:
     """Get WhatsApp chats matching specified criteria.
 
@@ -177,7 +230,7 @@ def list_chats(
     return chats
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "Get Chat", read_only=True, idempotent=True, open_world=False)
 def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]:
     """Get WhatsApp chat metadata by JID.
 
@@ -189,7 +242,7 @@ def get_chat(chat_jid: str, include_last_message: bool = True) -> dict[str, Any]
     return chat
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "Get Message Context", read_only=True, idempotent=True, open_world=False)
 def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dict[str, Any]:
     """Get context around a specific WhatsApp message.
 
@@ -207,7 +260,7 @@ def get_message_context(message_id: str, before: int = 5, after: int = 5) -> dic
     return context
 
 
-@mcp.tool(annotations=WRITE)
+@tool("send", "Send Message", read_only=False)
 def send_message(recipient: str, message: str, mentioned_jids: list[str] | None = None) -> dict[str, Any]:
     """Send a WhatsApp message to a person or group. For group chats use the JID.
 
@@ -223,7 +276,7 @@ def send_message(recipient: str, message: str, mentioned_jids: list[str] | None 
     return whatsapp_send_message(recipient, message, mentioned_jids)
 
 
-@mcp.tool(annotations=WRITE)
+@tool("media", "Send File", read_only=False)
 def send_file(recipient: str, media_path: str) -> dict[str, Any]:
     """Send a file such as a picture, raw audio, video or document via WhatsApp to the specified recipient. For group messages use the JID.
 
@@ -238,7 +291,7 @@ def send_file(recipient: str, media_path: str) -> dict[str, Any]:
     return whatsapp_send_file(recipient, media_path)
 
 
-@mcp.tool(annotations=WRITE)
+@tool("media", "Send Audio Message", read_only=False)
 def send_audio_message(recipient: str, media_path: str) -> dict[str, Any]:
     """Send any audio file as a WhatsApp audio message to the specified recipient. For group messages use the JID. If it errors due to ffmpeg not being installed, use send_file instead.
 
@@ -253,7 +306,7 @@ def send_audio_message(recipient: str, media_path: str) -> dict[str, Any]:
     return whatsapp_audio_voice_message(recipient, media_path)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("media", "Download Media", read_only=True, idempotent=True, open_world=False)
 def download_media(message_id: str, chat_jid: str) -> Any:
     """Download media from a WhatsApp message and get the local file path.
 
@@ -290,7 +343,7 @@ def download_media(message_id: str, chat_jid: str) -> Any:
     return status
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "List All Contacts", read_only=True, idempotent=True, open_world=False)
 def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
     """List all WhatsApp contacts with their information.
 
@@ -303,11 +356,15 @@ def list_all_contacts(limit: int = 100) -> list[dict[str, Any]]:
     return whatsapp_list_all_contacts(limit)
 
 
-@mcp.tool(
-    annotations=READ_ONLY,
+@tool(
+    "core",
+    "Get Contact Context",
+    read_only=True,
+    idempotent=True,
+    open_world=False,
     description=(
         "Get contact details plus optional related chats and last interaction. "
-        "Prefer this over get_contact_details, get_direct_chat_by_contact, get_contact_chats, and get_last_interaction."
+        "Use after search_contacts when you need more context for a person."
     ),
 )
 def get_contact_context(
@@ -334,14 +391,16 @@ def get_contact_context(
     return result
 
 
-@mcp.tool(
-    annotations=WRITE,
+@tool(
+    "contacts_write",
+    "Manage Nickname",
+    read_only=False,
     description=(
         "Manage custom contact nicknames. "
-        "Use action='set', 'get', 'remove', or 'list'. Prefer this over set_nickname/get_nickname/remove_nickname/list_nicknames."
+        "Use action='set', 'get', 'remove', or 'list'. This changes only local nickname metadata."
     ),
 )
-def manage_nickname(action: str, jid: str | None = None, nickname: str | None = None) -> dict[str, Any]:
+def manage_nickname(action: NicknameAction, jid: str | None = None, nickname: str | None = None) -> dict[str, Any]:
     """Manage custom contact nicknames with one action-based tool."""
     allowed = ("set", "get", "remove", "list")
     if action not in allowed:
@@ -363,7 +422,7 @@ def manage_nickname(action: str, jid: str | None = None, nickname: str | None = 
 # Phase 1 Features: Reactions, Edit, Delete, Group Info, Mark Read
 
 
-@mcp.tool(annotations=WRITE)
+@tool("send", "Send Reaction", read_only=False)
 def send_reaction(chat_jid: str, message_id: str, emoji: str) -> dict[str, Any]:
     """Send an emoji reaction to a WhatsApp message.
 
@@ -378,7 +437,7 @@ def send_reaction(chat_jid: str, message_id: str, emoji: str) -> dict[str, Any]:
     return whatsapp_send_reaction(chat_jid, message_id, emoji)
 
 
-@advanced_tool(annotations=WRITE)
+@tool("message_admin", "Edit Message", read_only=False)
 def edit_message(chat_jid: str, message_id: str, new_content: str) -> dict[str, Any]:
     """Edit a previously sent WhatsApp message.
 
@@ -393,7 +452,7 @@ def edit_message(chat_jid: str, message_id: str, new_content: str) -> dict[str, 
     return whatsapp_edit_message(chat_jid, message_id, new_content)
 
 
-@advanced_tool(annotations=DESTRUCTIVE)
+@tool("message_admin", "Delete Message", read_only=False, destructive=True)
 def delete_message(chat_jid: str, message_id: str, sender_jid: str | None = None) -> dict[str, Any]:
     """Delete/revoke a WhatsApp message.
 
@@ -408,7 +467,7 @@ def delete_message(chat_jid: str, message_id: str, sender_jid: str | None = None
     return whatsapp_delete_message(chat_jid, message_id, sender_jid)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "Get Group Info", read_only=True, idempotent=True, open_world=False)
 def get_group_info(group_jid: str) -> dict[str, Any]:
     """Get information about a WhatsApp group.
 
@@ -421,7 +480,7 @@ def get_group_info(group_jid: str) -> dict[str, Any]:
     return whatsapp_get_group_info(group_jid)
 
 
-@advanced_tool(annotations=WRITE)
+@tool("message_admin", "Mark Read", read_only=False)
 def mark_read(chat_jid: str, message_ids: list[str], sender_jid: str | None = None) -> dict[str, Any]:
     """Mark WhatsApp messages as read (sends blue ticks).
 
@@ -439,16 +498,19 @@ def mark_read(chat_jid: str, message_ids: list[str], sender_jid: str | None = No
 # Phase 2: Group Management
 
 
-@advanced_tool(
-    annotations=DESTRUCTIVE,
+@tool(
+    "groups",
+    "Manage Group",
+    read_only=False,
+    destructive=True,
     description=(
         "Manage WhatsApp groups with one composable tool. "
         "Use action='create', 'add_members', 'remove_members', 'promote_admin', 'demote_admin', 'leave', or 'update'. "
-        "Prefer this over create_group/add_group_members/remove_group_members/promote_to_admin/demote_admin/leave_group/update_group."
+        "Requires group admin rights for most actions."
     ),
 )
 def manage_group(
-    action: str,
+    action: GroupAction,
     group_jid: str | None = None,
     name: str | None = None,
     participants: list[str] | None = None,
@@ -511,7 +573,7 @@ def manage_group(
 # Phase 3: Polls
 
 
-@mcp.tool(annotations=WRITE)
+@tool("send", "Create Poll", read_only=False)
 def create_poll(chat_jid: str, question: str, options: list[str], multi_select: bool = False) -> dict[str, Any]:
     """Create and send a poll to a WhatsApp chat.
 
@@ -530,7 +592,7 @@ def create_poll(chat_jid: str, question: str, options: list[str], multi_select: 
 # Phase 4: History Sync
 
 
-@mcp.tool(annotations=WRITE)
+@tool("history", "Request History", read_only=False)
 def request_history(
     chat_jid: str, oldest_msg_id: str, oldest_msg_timestamp: int, oldest_msg_from_me: bool = False, count: int = 50
 ) -> dict[str, Any]:
@@ -561,8 +623,8 @@ def request_history(
 # Phase 5: Advanced Features
 
 
-@advanced_tool(annotations=WRITE)
-def set_presence(presence: str) -> dict[str, Any]:
+@tool("presence", "Set Presence", read_only=False)
+def set_presence(presence: PresenceState) -> dict[str, Any]:
     """Set your own presence status (available/unavailable).
 
     Args:
@@ -574,7 +636,7 @@ def set_presence(presence: str) -> dict[str, Any]:
     return whatsapp_set_presence(presence)
 
 
-@advanced_tool(annotations=WRITE)
+@tool("presence", "Subscribe Presence", read_only=False)
 def subscribe_presence(jid: str) -> dict[str, Any]:
     """Subscribe to presence updates for a contact.
 
@@ -590,7 +652,7 @@ def subscribe_presence(jid: str) -> dict[str, Any]:
     return whatsapp_subscribe_presence(jid)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool("core", "Get Profile Picture", read_only=True, idempotent=True, open_world=False)
 def get_profile_picture(jid: str, preview: bool = False) -> dict[str, Any]:
     """Get the profile picture URL for a user or group.
 
@@ -604,34 +666,42 @@ def get_profile_picture(jid: str, preview: bool = False) -> dict[str, Any]:
     return whatsapp_get_profile_picture(jid, preview)
 
 
-@advanced_tool(
-    annotations=DESTRUCTIVE,
-    description=(
-        "Manage blocked WhatsApp users. Use action='list', 'block', or 'unblock'. "
-        "Prefer this over get_blocklist/block_user/unblock_user."
-    ),
+@tool("account_admin", "Get Blocklist", read_only=True, idempotent=True, open_world=False)
+def get_blocklist() -> dict[str, Any]:
+    """Get the list of blocked WhatsApp users.
+
+    Returns:
+        A dictionary with users list and count
+    """
+    return whatsapp_get_blocklist()
+
+
+@tool(
+    "account_admin",
+    "Manage Blocklist",
+    read_only=False,
+    destructive=True,
+    description=("Block or unblock WhatsApp users. Use get_blocklist for read-only listing."),
 )
-def manage_blocklist(action: str, jid: str | None = None) -> dict[str, Any]:
-    """List, block, or unblock users through one action-based tool."""
-    allowed = ("list", "block", "unblock")
+def manage_blocklist(action: BlocklistAction, jid: str) -> dict[str, Any]:
+    """Block or unblock users through one action-based tool."""
+    allowed = ("block", "unblock")
     if action not in allowed:
         return _invalid_action(action, allowed, "manage_blocklist")
-    if action == "list":
-        return whatsapp_get_blocklist()
     if not jid:
         return {"success": False, "error": "jid is required for block/unblock", "use_tool": "manage_blocklist"}
     return whatsapp_update_blocklist(jid, action)
 
 
-@advanced_tool(
-    annotations=DESTRUCTIVE,
-    description=(
-        "Manage WhatsApp newsletters/channels. Use action='follow', 'unfollow', or 'create'. "
-        "Prefer this over follow_newsletter/unfollow_newsletter/create_newsletter."
-    ),
+@tool(
+    "newsletter",
+    "Manage Newsletter",
+    read_only=False,
+    destructive=True,
+    description=("Follow, unfollow, or create WhatsApp newsletters/channels."),
 )
 def manage_newsletter(
-    action: str,
+    action: NewsletterAction,
     jid: str | None = None,
     name: str | None = None,
     description: str = "",
@@ -652,5 +722,8 @@ def manage_newsletter(
 
 
 if __name__ == "__main__":
-    # Run with stdio transport for Claude Code CLI
-    mcp.run(transport="stdio")
+    transport = os.getenv("MCP_TRANSPORT", "stdio")
+    if transport in {"sse", "streamable-http"}:
+        mcp.settings.host = os.getenv("HOST", "0.0.0.0")
+        mcp.settings.port = int(os.getenv("PORT", "8081"))
+    mcp.run(transport=transport)

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -74,7 +74,7 @@ ALL_TOOLSETS = {
     "account_admin",
     "newsletter",
 }
-DEFAULT_TOOLSETS = {"core", "send", "media"}
+DEFAULT_TOOLSETS = set(ALL_TOOLSETS)
 ENABLED_TOOLSETS = {
     part.strip().lower()
     for part in os.getenv("WHATSAPP_MCP_TOOLSETS", ",".join(sorted(DEFAULT_TOOLSETS))).split(",")

--- a/whatsapp-mcp-server/tests/test_main_tools.py
+++ b/whatsapp-mcp-server/tests/test_main_tools.py
@@ -1,37 +1,150 @@
 import importlib
+from pathlib import Path
+
+DEFAULT_TOOLS = {
+    "search_contacts",
+    "list_messages",
+    "list_chats",
+    "get_chat",
+    "get_message_context",
+    "send_message",
+    "send_file",
+    "send_audio_message",
+    "download_media",
+    "list_all_contacts",
+    "get_contact_context",
+    "send_reaction",
+    "get_group_info",
+    "create_poll",
+    "get_profile_picture",
+}
+
+ALL_TOOLS = DEFAULT_TOOLS | {
+    "manage_nickname",
+    "edit_message",
+    "delete_message",
+    "mark_read",
+    "manage_group",
+    "request_history",
+    "set_presence",
+    "subscribe_presence",
+    "get_blocklist",
+    "manage_blocklist",
+    "manage_newsletter",
+}
 
 
-def test_curated_tool_surface_hides_deprecated_wrappers():
+def reload_main(monkeypatch, toolsets: str | None = None):
+    if toolsets is None:
+        monkeypatch.delenv("WHATSAPP_MCP_TOOLSETS", raising=False)
+    else:
+        monkeypatch.setenv("WHATSAPP_MCP_TOOLSETS", toolsets)
+    monkeypatch.delenv("WHATSAPP_MCP_TOOLS", raising=False)
+
+    import main
+
+    return importlib.reload(main)
+
+
+def tool_names(main) -> set[str]:
+    return {tool.name for tool in main.mcp._tool_manager.list_tools()}
+
+
+def test_default_tool_surface_is_small_and_safe(monkeypatch):
+    main = reload_main(monkeypatch)
+
+    assert tool_names(main) == DEFAULT_TOOLS
+    assert "manage_group" not in tool_names(main)
+    assert "delete_message" not in tool_names(main)
+    assert "manage_blocklist" not in tool_names(main)
+    assert "manage_newsletter" not in tool_names(main)
+
+
+def test_all_toolsets_expose_full_curated_surface(monkeypatch):
+    main = reload_main(monkeypatch, "all")
+
+    assert tool_names(main) == ALL_TOOLS
+    assert "get_contact_chats" not in tool_names(main)
+    assert "create_group" not in tool_names(main)
+    assert "block_user" not in tool_names(main)
+    assert "follow_newsletter" not in tool_names(main)
+
+
+def test_explicit_tool_allowlist_can_add_single_advanced_tool(monkeypatch):
+    monkeypatch.delenv("WHATSAPP_MCP_TOOLSETS", raising=False)
+    monkeypatch.setenv("WHATSAPP_MCP_TOOLS", "manage_group")
+
     import main
 
     main = importlib.reload(main)
-    tool_names = {tool.name for tool in main.mcp._tool_manager.list_tools()}
+    names = tool_names(main)
 
-    assert len(tool_names) == 25
-    assert "get_contact_context" in tool_names
-    assert "manage_nickname" in tool_names
-    assert "manage_group" in tool_names
-    assert "manage_newsletter" in tool_names
-    assert "get_contact_chats" not in tool_names
-    assert "create_group" not in tool_names
-    assert "block_user" not in tool_names
-    assert "follow_newsletter" not in tool_names
+    assert "manage_group" in names
+    assert "manage_blocklist" not in names
 
 
-def test_all_exposed_tools_have_annotations():
-    import main
+def test_all_exposed_tools_have_titles_and_annotations(monkeypatch):
+    main = reload_main(monkeypatch, "all")
 
-    main = importlib.reload(main)
-    for tool in main.mcp._tool_manager.list_tools():
-        assert tool.annotations is not None, tool.name
+    for exposed_tool in main.mcp._tool_manager.list_tools():
+        assert exposed_tool.title, exposed_tool.name
+        assert exposed_tool.annotations is not None, exposed_tool.name
+        assert exposed_tool.annotations.title == exposed_tool.title
 
 
-def test_merged_tool_invalid_action_guides_model():
-    import main
+def test_enum_schemas_for_action_and_sort_fields(monkeypatch):
+    main = reload_main(monkeypatch, "all")
 
-    main = importlib.reload(main)
+    manage_group = main.mcp._tool_manager.get_tool("manage_group")
+    set_presence = main.mcp._tool_manager.get_tool("set_presence")
+    list_chats = main.mcp._tool_manager.get_tool("list_chats")
+    manage_blocklist = main.mcp._tool_manager.get_tool("manage_blocklist")
+
+    assert manage_group.parameters["properties"]["action"]["enum"] == [
+        "create",
+        "add_members",
+        "remove_members",
+        "promote_admin",
+        "demote_admin",
+        "leave",
+        "update",
+    ]
+    assert set_presence.parameters["properties"]["presence"]["enum"] == ["available", "unavailable"]
+    assert list_chats.parameters["properties"]["sort_by"]["enum"] == ["last_active", "name"]
+    assert manage_blocklist.parameters["properties"]["action"]["enum"] == ["block", "unblock"]
+
+
+def test_merged_tool_invalid_action_guides_model(monkeypatch):
+    main = reload_main(monkeypatch, "all")
     result = main.manage_nickname("rename", jid="123@s.whatsapp.net", nickname="Felix")
 
     assert result["success"] is False
     assert result["use_tool"] == "manage_nickname"
     assert result["allowed_actions"] == ["set", "get", "remove", "list"]
+
+
+def test_manage_group_forwards_create_action(monkeypatch):
+    main = reload_main(monkeypatch, "all")
+    called = {}
+
+    def fake_create_group(name, participants):
+        called["args"] = (name, participants)
+        return {"success": True, "group_jid": "1@g.us"}
+
+    monkeypatch.setattr(main, "whatsapp_create_group", fake_create_group)
+
+    result = main.manage_group("create", name="Ops", participants=["1@s.whatsapp.net"])
+
+    assert result["success"] is True
+    assert called["args"] == ("Ops", ["1@s.whatsapp.net"])
+
+
+def test_docker_mcp_entrypoint_uses_curated_main_server():
+    root = Path(__file__).resolve().parents[2]
+    dockerfile = (root / "Dockerfile.mcp").read_text(encoding="utf-8")
+    compose = (root / "docker-compose.yaml").read_text(encoding="utf-8")
+
+    assert "python main.py" in dockerfile
+    assert "python gradio-main.py" not in dockerfile
+    assert "MCP_TRANSPORT=streamable-http" in compose
+    assert "WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-core,send,media}" in compose

--- a/whatsapp-mcp-server/tests/test_main_tools.py
+++ b/whatsapp-mcp-server/tests/test_main_tools.py
@@ -50,20 +50,20 @@ def tool_names(main) -> set[str]:
     return {tool.name for tool in main.mcp._tool_manager.list_tools()}
 
 
-def test_default_tool_surface_is_small_and_safe(monkeypatch):
+def test_default_tool_surface_exposes_full_curated_surface(monkeypatch):
     main = reload_main(monkeypatch)
+
+    assert tool_names(main) == ALL_TOOLS
+
+
+def test_lean_toolsets_expose_small_safe_surface(monkeypatch):
+    main = reload_main(monkeypatch, "core,send,media")
 
     assert tool_names(main) == DEFAULT_TOOLS
     assert "manage_group" not in tool_names(main)
     assert "delete_message" not in tool_names(main)
     assert "manage_blocklist" not in tool_names(main)
     assert "manage_newsletter" not in tool_names(main)
-
-
-def test_all_toolsets_expose_full_curated_surface(monkeypatch):
-    main = reload_main(monkeypatch, "all")
-
-    assert tool_names(main) == ALL_TOOLS
     assert "get_contact_chats" not in tool_names(main)
     assert "create_group" not in tool_names(main)
     assert "block_user" not in tool_names(main)
@@ -71,7 +71,7 @@ def test_all_toolsets_expose_full_curated_surface(monkeypatch):
 
 
 def test_explicit_tool_allowlist_can_add_single_advanced_tool(monkeypatch):
-    monkeypatch.delenv("WHATSAPP_MCP_TOOLSETS", raising=False)
+    monkeypatch.setenv("WHATSAPP_MCP_TOOLSETS", "core,send,media")
     monkeypatch.setenv("WHATSAPP_MCP_TOOLS", "manage_group")
 
     import main
@@ -147,4 +147,4 @@ def test_docker_mcp_entrypoint_uses_curated_main_server():
     assert "python main.py" in dockerfile
     assert "python gradio-main.py" not in dockerfile
     assert "MCP_TRANSPORT=streamable-http" in compose
-    assert "WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-core,send,media}" in compose
+    assert "WHATSAPP_MCP_TOOLSETS=${WHATSAPP_MCP_TOOLSETS:-all}" in compose


### PR DESCRIPTION
## Summary

- **Gate MCP toolsets** — adds ability to enable/disable specific tool groups
- **Default all toolsets on** — out-of-the-box all tools available without config
- **Dockerfile.mcp optimisation** — 66% image size reduction (2.43GB → 837MB)
  - `python:3.13` → `python:3.13-slim` (~600MB saved)
  - Multi-stage build: deps installed into isolated venv, build tools excluded from final image
  - Removed `gradio`/`gradio_client` from Docker deps — only used in `gradio-main.py` (local dev UI), not the `main.py` entrypoint; still available locally via `.venv`
  - `ffmpeg` retained for audio conversion

## Test plan

- [x] Image builds successfully
- [x] Container starts — all MCP tool handlers register correctly
- [x] Uvicorn up on port 8081
- [x] `main.py` entrypoint has no gradio imports — verified in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)