### PR TITLE
Fix failing Security Scan workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.12'
           cache-dependency-path: whatsapp-bridge/go.sum
 
       - name: Run govulncheck

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,13 +1,31 @@
-# Extend the default gitleaks ruleset, then allowlist documented example values.
+# Extends the default gitleaks ruleset rather than replacing it.
 [extend]
 useDefault = true
 
-# Placeholder secret_token values that appear in webhook configuration examples
-# throughout the docs (and in renamed copies of those docs in git history).
-# These are illustrative, not real credentials.
-[[allowlists]]
-description = "Documented example secret_token values, not real credentials"
-regexTarget = "match"
+# The webhook docs use placeholder credentials in example JSON payloads, e.g.
+#   "secret_token": "family-secret-123"
+# alongside https://api.example.com/... These are illustrative, not real
+# credentials, but the generic-api-key rule flags them on every full-history
+# scan — which is what the weekly scheduled run does, hence the recurring
+# failures. (An older copy of these docs at whatsapp-bridge/WEBHOOK_README.md
+# is still reachable in git history, so deleting the current file wouldn't
+# help.)
+#
+# This is expressed as a rule-scoped allowlist ([[rules]] + [rules.allowlist])
+# rather than a global [[allowlists]] block. That distinction matters:
+# gitleaks-action@v2 pins gitleaks 8.24.3, which does not honour a global
+# allowlist using regexTarget = "match". A global block therefore looks correct
+# when tested against a current local gitleaks (8.30+) while doing nothing in
+# CI. The rule-scoped form works on both.
+#
+# The allowlist is deliberately narrow: it matches the placeholder *values*
+# themselves rather than whole lines or file paths, so a genuine secret
+# committed to a Markdown file is still reported.
+[[rules]]
+id = "generic-api-key"
+[rules.allowlist]
+regexTarget = "secret"
 regexes = [
-  '''secret_token"?\s*:\s*"(family-secret-123|super_secret_key_123)"''',
+  '''^(optional|new|family|emergency)-secret(-\d+)?$''',
+  '''^super_secret_key_123$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Extend the default gitleaks ruleset, then allowlist documented example values.
+[extend]
+useDefault = true
+
+# Placeholder secret_token values that appear in webhook configuration examples
+# throughout the docs (and in renamed copies of those docs in git history).
+# These are illustrative, not real credentials.
+[[allowlists]]
+description = "Documented example secret_token values, not real credentials"
+regexTarget = "match"
+regexes = [
+  '''secret_token"?\s*:\s*"(family-secret-123|super_secret_key_123)"''',
+]


### PR DESCRIPTION
The weekly **Security Scan** cron has been failing on every run. Two of its four jobs fail.

## `go-security` (govulncheck)

Go is pinned to `1.25.10`, which is affected by two Go **standard-library** CVEs:
- [`GO-2026-5039`](https://pkg.go.dev/vuln/GO-2026-5039) — `net/textproto` (fixed in go1.25.11)
- [`GO-2026-5037`](https://pkg.go.dev/vuln/GO-2026-5037) — `crypto/x509` (fixed in go1.25.11)

**Fix:** bump the pin to `1.25.12` (still the latest 1.25 patch).

## `secrets-scan` (gitleaks)

False positive on example `secret_token` values in the webhook docs (`family-secret-123` / `super_secret_key_123`). These are illustrative placeholders sitting next to `https://api.example.com/...`, not real credentials.

They're also reachable at an older path, `whatsapp-bridge/WEBHOOK_README.md`, so deleting or editing the current docs wouldn't clear them from a history scan.

This also explains why the failure is **schedule-only**: `gitleaks-action` scans only the pushed commits on `push`/`pull_request`, but scans **full history** on `schedule`.

**Fix:** add a `.gitleaks.toml` allowlisting those placeholder values.

## ⚠️ Correction to the original version of this PR

The first version of this PR used a global `[[allowlists]]` block with `regexTarget = "match"`. **That does not work in CI**, and I originally verified it incorrectly.

`gitleaks-action@v2` pins gitleaks **8.24.3**, which doesn't honour that form. A current local gitleaks (8.30+) does. So the config suppressed the finding locally while doing nothing in CI — and the green Security Scan on this PR was no evidence either way, because PR runs scan incrementally and never touch the offending commit.

I hit exactly this in my own fork: the same config merged, and the next scheduled run failed anyway.

This is now a rule-scoped `[[rules]]` + `[rules.allowlist]` allowlist, which works on both versions. It matches the placeholder **values** rather than whole lines or file paths, so a genuine secret in a Markdown file is still reported.

## Verification

Run against gitleaks **8.24.3** (what CI uses) and **8.30.1**:

| Check | 8.24.3 | 8.30.1 |
|---|---|---|
| Full repo history | no leaks | no leaks |
| Working tree | no leaks | no leaks |
| **Previous config in this PR** | **2 leaks** ← reproduces the CI failure | no leaks ← why it looked fixed |
| Planted high-entropy secret in a `.md` | detected | detected |
| Planted Stripe key | detected | detected |

The third row is the bug in one line: the old config behaved differently on the two versions.

## Notes

- Rebased onto current `main` (was 4 commits behind).
- The `Lint` failure on this branch is **pre-existing on `main`** and unrelated: ruff `I001` import-sorting in `whatsapp-mcp-server/main.py:3` and `whatsapp.py:30`. This PR touches no Python. Happy to fix it here or in a separate PR, whichever you prefer.
- A green Security Scan on this PR still won't prove the cron is fixed, for the incremental-scan reason above. The cross-version table is the actual evidence; the next Sunday run is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)