### PR TITLE
Cap mcp below 2.0, which removed mcp.server.fastmcp

### DIFF
--- a/whatsapp-mcp-server/requirements.txt
+++ b/whatsapp-mcp-server/requirements.txt
@@ -1,5 +1,8 @@
 httpx>=0.28.1
-mcp[cli]>=1.23.0
+# Capped below 2.0: it removes mcp.server.fastmcp, which main.py imports.
+# Without the cap a fresh build picks up 2.0 and the server dies on import
+# with ModuleNotFoundError.
+mcp[cli]>=1.23.0,<2.0.0
 requests>=2.32.3
 starlette>=1.3.1
 uvicorn>=0.23.2


### PR DESCRIPTION
`requirements.txt` asks for `mcp[cli]>=1.23.0` with no upper bound, but mcp 2.0.0 dropped `mcp.server.fastmcp` — which `main.py` imports at module scope, for both `FastMCP` and `utilities.types.Image`.

Any build from a clean environment now resolves to 2.0 and dies on import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Existing images keep working only because they were built before 2.0 was released, which makes this easy to miss until a rebuild. I hit it deploying a fresh build.

## What changed

Capped at `<2.0.0`, which resolves to 1.29.0 and imports cleanly. Verified both: unpinned fails with the error above, capped imports fine.

Porting to the 2.x API is separate work — this just unbreaks builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)