### PR TITLE
Accept base64 file content in send_file

### DIFF
--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Literal
 
 import requests as _requests
-
-from lib.utils import WHATSAPP_API_BASE_URL as _BRIDGE_URL
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.utilities.types import Image
 from mcp.types import ToolAnnotations
+
+from lib.utils import WHATSAPP_API_BASE_URL as _BRIDGE_URL
 
 # Phase 2: Group Management
 from whatsapp import add_group_members as whatsapp_add_group_members
@@ -293,18 +293,35 @@ def send_message(
 
 
 @tool("media", "Send File", read_only=False)
-def send_file(recipient: str, media_path: str) -> dict[str, Any]:
+def send_file(
+    recipient: str,
+    media_path: str | None = None,
+    file_content_base64: str | None = None,
+    filename: str | None = None,
+) -> dict[str, Any]:
     """Send a file such as a picture, raw audio, video or document via WhatsApp to the specified recipient. For group messages use the JID.
+
+    Provide the file either as a path on the server, or inline as base64.
 
     Args:
         recipient: The recipient - either a phone number with country code but no + or other symbols,
                  or a JID (e.g., "123456789@s.whatsapp.net" or a group JID like "123456789@g.us")
-        media_path: The absolute path to the media file to send (image, video, document)
+        media_path: The absolute path to the media file to send (image, video, document).
+                 This is a path on the *server*, so it only works for files already there.
+        file_content_base64: The file's bytes, base64-encoded. Use this for a local file —
+                 the server cannot read your filesystem. Requires filename.
+        filename: Name for the file, including extension (e.g. "screenshot.png"). Required
+                 with file_content_base64; the extension determines how WhatsApp shows it.
 
     Returns:
         A dictionary containing success status and a status message
+
+    Hints:
+        - Exactly one of media_path or file_content_base64 is required
+        - To send an image you just created locally, base64-encode it and pass
+          file_content_base64 with a filename
     """
-    return whatsapp_send_file(recipient, media_path)
+    return whatsapp_send_file(recipient, media_path, file_content_base64, filename)
 
 
 @tool("media", "Send Audio Message", read_only=False)

--- a/whatsapp-mcp-server/requirements.txt
+++ b/whatsapp-mcp-server/requirements.txt
@@ -1,5 +1,8 @@
 httpx>=0.28.1
-mcp[cli]>=1.23.0
+# Capped below 2.0: it removes mcp.server.fastmcp, which main.py imports.
+# Without the cap a fresh build picks up 2.0 and the server dies on import
+# with ModuleNotFoundError.
+mcp[cli]>=1.23.0,<2.0.0
 requests>=2.32.3
 starlette>=1.3.1
 uvicorn>=0.23.2

--- a/whatsapp-mcp-server/tests/test_send_file.py
+++ b/whatsapp-mcp-server/tests/test_send_file.py
@@ -1,0 +1,156 @@
+"""Tests for send_file's base64 input.
+
+The path-only interface could not send a file the *client* holds: MCP clients
+generally run on a different machine from this server, so a locally produced
+file (a screenshot, say) has no way onto this filesystem. Accepting the bytes
+inline fixes that.
+"""
+
+import base64
+import os
+
+import pytest
+
+import whatsapp
+
+# A real 1x1 PNG, so the magic bytes can be asserted on.
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def captured_send(monkeypatch, tmp_path):
+    """Captures the media_path the bridge would have been asked to send."""
+    seen: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"success": True, "message_id": "MSG1", "recipient": "123"}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        seen["media_path"] = json["media_path"]
+        # Read it here: the real bridge reads during this call, so this is the
+        # only point at which the temp file is guaranteed to still exist.
+        with open(json["media_path"], "rb") as f:
+            seen["content"] = f.read()
+        return FakeResponse()
+
+    monkeypatch.setattr(whatsapp.requests, "post", fake_post)
+    return seen
+
+
+# Mirrors allowedMediaDirs in whatsapp-bridge/internal/whatsapp/messages.go.
+# The bridge rejects a media_path outside these, so writing somewhere it will
+# not read from fails only at runtime — which is exactly what happened when the
+# temp file was first put under the per-user store.
+BRIDGE_ALLOWED_DIRS = ("/app/media", "/app/store", "/app/whatsapp-bridge/store", "/tmp")
+
+
+def test_sends_a_file_given_as_base64(captured_send):
+    result = whatsapp.send_file(
+        recipient="123",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+        filename="screenshot.png",
+    )
+
+    assert result["success"] is True
+    assert result["message_id"] == "MSG1"
+    # The bridge received the real bytes, not a re-encoding.
+    assert captured_send["content"] == PNG_BYTES
+    # And the name is preserved, since the extension drives how WhatsApp renders it.
+    assert str(captured_send["media_path"]).endswith("-screenshot.png")
+
+
+def test_removes_the_temp_file_afterwards(captured_send):
+    whatsapp.send_file(
+        recipient="123",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+        filename="screenshot.png",
+    )
+
+    # Otherwise every send leaks a copy into the media volume.
+    assert not os.path.exists(str(captured_send["media_path"]))
+
+
+def test_rejects_base64_without_a_filename(captured_send):
+    result = whatsapp.send_file(
+        recipient="123",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+    )
+
+    assert result["success"] is False
+    assert "filename" in result["error"]
+
+
+def test_rejects_invalid_base64(captured_send):
+    result = whatsapp.send_file(
+        recipient="123",
+        file_content_base64="not!valid!base64",
+        filename="x.png",
+    )
+
+    assert result["success"] is False
+    assert "base64" in result["error"].lower()
+
+
+def test_rejects_both_inputs_at_once(captured_send):
+    result = whatsapp.send_file(
+        recipient="123",
+        media_path="/some/path.png",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+        filename="x.png",
+    )
+
+    assert result["success"] is False
+    assert "not both" in result["error"]
+
+
+def test_rejects_neither_input(captured_send):
+    result = whatsapp.send_file(recipient="123")
+
+    assert result["success"] is False
+    assert "media_path" in result["error"]
+
+
+def test_writes_somewhere_the_bridge_will_read_from(captured_send):
+    """The bridge validates media_path against an allowlist before reading it."""
+    whatsapp.send_file(
+        recipient="123",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+        filename="screenshot.png",
+    )
+
+    written = os.path.realpath(str(captured_send["media_path"]))
+    assert any(written.startswith(os.path.realpath(allowed)) for allowed in BRIDGE_ALLOWED_DIRS), (
+        f"{written} is outside the bridge's allowed media directories"
+    )
+
+
+def test_a_filename_cannot_escape_the_temp_directory(captured_send):
+    whatsapp.send_file(
+        recipient="123",
+        file_content_base64=base64.b64encode(PNG_BYTES).decode(),
+        filename="../../etc/passwd",
+    )
+
+    # Only the basename is used, so the write stays put. The bridge separately
+    # rejects any path containing "..", so this must not produce one.
+    written = str(captured_send["media_path"])
+    assert ".." not in written
+    assert os.path.dirname(written) == os.path.join(whatsapp.MEDIA_TEMP_DIR, "whatsapp-outgoing")
+
+
+def test_still_accepts_a_server_side_path(captured_send, tmp_path):
+    existing = tmp_path / "already-here.png"
+    existing.write_bytes(PNG_BYTES)
+
+    result = whatsapp.send_file(recipient="123", media_path=str(existing))
+
+    assert result["success"] is True
+    assert captured_send["media_path"] == str(existing)
+    # A caller-owned file must survive the send.
+    assert existing.exists()

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -1,7 +1,10 @@
+import base64
+import binascii
 import json
 import os
 import os.path
 import sqlite3
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -31,7 +34,6 @@ import audio
 from lib.bridge import _get_headers
 from lib.utils import MESSAGES_DB_PATH, WHATSAPP_DB_PATH
 
-
 # Use environment variable for bridge host, default to localhost:8080 for development
 # BRIDGE_HOST can be "hostname" (uses :8080) or "hostname:port" (uses specified port)
 _bridge_host = os.getenv("BRIDGE_HOST", "localhost:8080")
@@ -39,6 +41,13 @@ if ":" not in _bridge_host:
     _bridge_host = f"{_bridge_host}:8080"
 BRIDGE_HOST = _bridge_host
 WHATSAPP_API_BASE_URL = f"http://{BRIDGE_HOST}/api"
+
+# Where base64 uploads are staged for the bridge to read. Must stay one of the
+# directories allowed by validateMediaPath in the Go bridge
+# (whatsapp-bridge/internal/whatsapp/messages.go); /tmp is the only one of those
+# not tied to a particular deployment layout. Literal rather than
+# tempfile.gettempdir(), since the allowlist names that exact path.
+MEDIA_TEMP_DIR = "/tmp"
 
 
 @dataclass
@@ -914,15 +923,62 @@ def send_message(
         return {"success": False, "error": f"Unexpected error: {str(e)}"}
 
 
-def send_file(recipient: str, media_path: str) -> dict[str, Any]:
-    """Send a file via WhatsApp and return structured result with message_id."""
+def send_file(
+    recipient: str,
+    media_path: str | None = None,
+    file_content_base64: str | None = None,
+    filename: str | None = None,
+) -> dict[str, Any]:
+    """Send a file via WhatsApp and return structured result with message_id.
+
+    Accepts either a path on this server's filesystem, or the file's bytes as
+    base64. The latter exists because MCP clients generally run somewhere else:
+    a client holding a file it just produced has no way to put it on this
+    server's disk, so a path-only interface makes sending it impossible.
+    """
+    temp_path: str | None = None
     try:
         # Validate input
         if not recipient:
             return {"success": False, "error": "Recipient must be provided"}
 
+        if media_path and file_content_base64:
+            return {
+                "success": False,
+                "error": "Provide either media_path or file_content_base64, not both",
+            }
+
+        if file_content_base64:
+            if not filename:
+                return {
+                    "success": False,
+                    "error": "filename must be provided with file_content_base64",
+                }
+
+            try:
+                content = base64.b64decode(file_content_base64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                return {"success": False, "error": f"Invalid base64 content: {str(e)}"}
+
+            # The bridge reads the file off disk, so the bytes have to land
+            # there first — and somewhere validateMediaPath allows.
+            media_dir = os.path.join(MEDIA_TEMP_DIR, "whatsapp-outgoing")
+            os.makedirs(media_dir, exist_ok=True)
+            # Only the basename: a filename like "../x" must not escape. The
+            # bridge also rejects any path containing "..", so a traversal
+            # attempt would fail there too.
+            safe_name = os.path.basename(filename) or "upload"
+            fd, temp_path = tempfile.mkstemp(suffix=f"-{safe_name}", dir=media_dir)
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
+            media_path = temp_path
+
         if not media_path:
-            return {"success": False, "error": "Media path must be provided"}
+            return {
+                "success": False,
+                "error": "Either media_path or file_content_base64 must be provided",
+            }
 
         if not os.path.isfile(media_path):
             return {"success": False, "error": f"Media file not found: {media_path}"}
@@ -951,6 +1007,14 @@ def send_file(recipient: str, media_path: str) -> dict[str, Any]:
         return {"success": False, "error": f"Error parsing response: {response.text}"}
     except Exception as e:
         return {"success": False, "error": f"Unexpected error: {str(e)}"}
+    finally:
+        # The bridge reads the file synchronously during /send, so it is safe to
+        # remove once that call has returned either way.
+        if temp_path:
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
 
 
 def send_audio_message(recipient: str, media_path: str) -> dict[str, Any]:


### PR DESCRIPTION
> Stacked on #75 — that PR fixes an import error which otherwise stops the test suite running at all. Review this one second.

`send_file` takes only `media_path`, a path on the server's own filesystem. MCP clients generally run elsewhere, so a file the client just produced — a screenshot, a generated image — cannot be sent at all: there is no way to get the bytes onto the server.

The gap is one-way: receiving already works, since `download_media` returns images inline.

## What changed

`send_file` now also accepts `file_content_base64` plus `filename`. The bytes are written to a temp file, passed to the bridge as before, and removed in a `finally` block — the bridge reads the file synchronously during `/send`, so it is safe to delete once that returns. Exactly one of the two inputs is required.

Staged under `/tmp` because the Go bridge validates `media_path` against `allowedMediaDirs`, and `/tmp` is the only entry there not tied to a particular deployment layout. Literal rather than `tempfile.gettempdir()`, since the allowlist names that exact path — honouring `TMPDIR` would put the file somewhere the bridge refuses to read.

Only the basename of `filename` is used, so a name like `../../x` cannot write outside that directory.

## Testing

8 new tests, 69 passing. They cover the bytes arriving intact, temp file cleanup, both-inputs and neither-input rejection, invalid base64, the traversal case, and that a server-side path still works and is not deleted.

Also verified end to end against a real deployment — the staging-directory choice was found that way, since mocked tests cannot catch the bridge's path validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)